### PR TITLE
Add coverage report to CI

### DIFF
--- a/.github/workflows/dotnet-sonar.yaml
+++ b/.github/workflows/dotnet-sonar.yaml
@@ -38,5 +38,11 @@ jobs:
       - name: Build and Test with Coverage
         run: bash scripts/run_tests.sh
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-report
+
       - name: End SonarCloud analysis
         run: dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -37,3 +37,9 @@ jobs:
 
       - name: Execute tests
         run: bash scripts/run_tests.sh
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-report

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -47,8 +47,13 @@ echo "📊 Gerando relatório de cobertura em formato OpenCover..."
 reportgenerator \
   -reports:$coverage_files \
   -targetdir:"$COVERAGE_OUTPUT" \
-  -reporttypes:OpenCover \
+  -reporttypes:"OpenCover;MarkdownSummaryGithub" \
   -filefilters:"+*.cs" \
   -verbosity:Error
+
+# Adiciona o sumário de cobertura no Job Summary do GitHub Actions, quando disponível
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" && -f "$COVERAGE_OUTPUT/SummaryGithub.md" ]]; then
+  cat "$COVERAGE_OUTPUT/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
+fi
 
 echo "✅ Relatório de cobertura gerado em: $COVERAGE_OUTPUT/opencover.xml"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -33,9 +33,10 @@ echo "📊 Instalando ReportGenerator..."
 dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.1.26 || true
 export PATH="$PATH:$HOME/.dotnet/tools"
 
-# Descobre todos os arquivos cobertura.cobertura.xml
+# Descobre todos os arquivos coverage.cobertura.xml e monta lista separada por ponto e vírgula
 echo "🔍 Procurando arquivos de cobertura..."
-coverage_files=$(find "$REPO_ROOT" -type f -name 'coverage.cobertura.xml')
+coverage_files=$(find "$REPO_ROOT" -type f -name 'coverage.cobertura.xml' -print0 | tr '\0' ';')
+coverage_files=${coverage_files%;} # remove ponto e vírgula final, se existir
 echo "Arquivos de cobertura encontrados: $coverage_files"
 
 if [[ -z "$coverage_files" ]]; then
@@ -45,7 +46,7 @@ fi
 
 echo "📊 Gerando relatório de cobertura em formato OpenCover..."
 reportgenerator \
-  -reports:$coverage_files \
+  -reports:"$coverage_files" \
   -targetdir:"$COVERAGE_OUTPUT" \
   -reporttypes:"OpenCover;MarkdownSummaryGithub" \
   -filefilters:"+*.cs" \


### PR DESCRIPTION
## Summary
- update scripts to generate Markdown summary coverage
- publish coverage as workflow artifact for test and sonar workflows

## Testing
- `bash scripts/run_tests.sh` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_688964353b7c83209deb09ba86ba8f31