### PR TITLE
Add shortcut button and YUP validation for login

### DIFF
--- a/src/Apps/erp/index.html
+++ b/src/Apps/erp/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ERP Front</title>
   </head>
-  <body>
+  <body style="margin: 0px;">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/src/Apps/erp/package.json
+++ b/src/Apps/erp/package.json
@@ -22,7 +22,9 @@
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.0",
-    "sql.js": "^1.13.0"
+    "sql.js": "^1.13.0",
+    "@hookform/resolvers": "^3.9.0",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/Apps/erp/shared/auth/application/session.ts
+++ b/src/Apps/erp/shared/auth/application/session.ts
@@ -1,0 +1,29 @@
+export interface SessionState {
+  username: string;
+  roles: string[];
+  token: string;
+}
+
+export type SessionAction =
+  | { type: 'SET'; payload: SessionState }
+  | { type: 'CLEAR' };
+
+export const initialSessionState: SessionState = {
+  username: '',
+  roles: [],
+  token: ''
+};
+
+export const sessionReducer = (
+  state: SessionState,
+  action: SessionAction
+): SessionState => {
+  switch (action.type) {
+    case 'SET':
+      return action.payload;
+    case 'CLEAR':
+      return initialSessionState;
+    default:
+      return state;
+  }
+};

--- a/src/Apps/erp/shared/auth/application/useLogin.ts
+++ b/src/Apps/erp/shared/auth/application/useLogin.ts
@@ -1,12 +1,9 @@
 import { useCallback, useEffect, useReducer, useState, MouseEvent } from 'react';
 import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
 import { authService } from '../infrastructure/authService';
-
-interface SessionState {
-  username: string;
-  roles: string[];
-  token: string;
-}
+import { sessionReducer, initialSessionState } from './session';
+import { loginValidationSchema } from './validation';
 
 interface LoginForm {
   username: string;
@@ -14,29 +11,13 @@ interface LoginForm {
   remember: boolean;
 }
 
-type SessionAction = { type: 'SET'; payload: SessionState } | { type: 'CLEAR' };
-
-const sessionReducer = (state: SessionState, action: SessionAction): SessionState => {
-  switch (action.type) {
-    case 'SET':
-      return action.payload;
-    case 'CLEAR':
-      return { username: '', roles: [], token: '' };
-    default:
-      return state;
-  }
-};
-
 export const useLogin = () => {
-  const [, dispatch] = useReducer(sessionReducer, {
-    username: '',
-    roles: [],
-    token: ''
-  });
+  const [, dispatch] = useReducer(sessionReducer, initialSessionState);
   const [showPassword, setShowPassword] = useState(false);
 
   const { control, handleSubmit, setValue, watch } = useForm<LoginForm>({
-    defaultValues: { username: '', password: '', remember: false }
+    defaultValues: { username: '', password: '', remember: false },
+    resolver: yupResolver(loginValidationSchema)
   });
 
   useEffect(() => {
@@ -83,9 +64,6 @@ export const useLogin = () => {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === 'Enter') {
-        handleSubmit(onSubmit)();
-      }
       if (e.altKey && e.key.toLowerCase() === 'r') {
         handleRecover();
       }
@@ -95,7 +73,7 @@ export const useLogin = () => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [handleSubmit, onSubmit, handleRecover, toggleShowPassword]);
+  }, [handleRecover, toggleShowPassword]);
 
   const clientLogoUrl = '/logo.png';
 
@@ -109,5 +87,3 @@ export const useLogin = () => {
     clientLogoUrl
   };
 };
-
-export type { SessionState };

--- a/src/Apps/erp/shared/auth/application/validation.ts
+++ b/src/Apps/erp/shared/auth/application/validation.ts
@@ -1,0 +1,7 @@
+import * as yup from 'yup';
+
+export const loginValidationSchema = yup.object({
+  username: yup.string().required('Usuário é obrigatório'),
+  password: yup.string().required('Senha é obrigatória'),
+  remember: yup.boolean()
+});

--- a/src/Apps/erp/shared/auth/presentation/Login.tsx
+++ b/src/Apps/erp/shared/auth/presentation/Login.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
+import { Button } from '../../components/components/Button';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
@@ -36,7 +36,6 @@ export const Login: React.FC = () => {
           label="Usuário"
           fullWidth
           margin="normal"
-          rules={{ required: 'Usuário é obrigatório' }}
         />
         <TextField
           name="password"
@@ -45,7 +44,6 @@ export const Login: React.FC = () => {
           type={showPassword ? 'text' : 'password'}
           fullWidth
           margin="normal"
-          rules={{ required: 'Senha é obrigatória' }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -61,7 +59,13 @@ export const Login: React.FC = () => {
           }}
         />
         <Checkbox name="remember" control={control} label="Salvar senha" />
-        <Button type="submit" variant="contained" fullWidth aria-label="Entrar no sistema" >
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          aria-label="Entrar no sistema"
+          shortcut={['Ctrl', 'Enter']}
+        >
           Entrar
         </Button>
         <Box mt={2}>

--- a/src/Apps/erp/shared/auth/presentation/Login.tsx
+++ b/src/Apps/erp/shared/auth/presentation/Login.tsx
@@ -7,6 +7,7 @@ import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
+const apiUrl = import.meta.env;
 
 import { useLogin } from '../application/useLogin';
 import { TextField } from '../../components/components/TextField';
@@ -25,6 +26,8 @@ export const Login: React.FC = () => {
     showPassword,
     clientLogoUrl
   } = useLogin();
+
+  console.log(apiUrl)
 
   return (
     <Box className="login-container">

--- a/src/Apps/erp/shared/components/components/Button.tsx
+++ b/src/Apps/erp/shared/components/components/Button.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+import MuiButton, { ButtonProps } from '@mui/material/Button';
+
+interface ShortcutButtonProps extends ButtonProps {
+  shortcut?: string[];
+}
+
+export const Button: React.FC<ShortcutButtonProps> = ({
+  shortcut,
+  children,
+  ...props
+}) => {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!shortcut) return;
+    const handler = (e: KeyboardEvent) => {
+      const keys = shortcut.map((k) => k.toLowerCase());
+      const ctrl = keys.includes('ctrl');
+      const alt = keys.includes('alt');
+      const shift = keys.includes('shift');
+      const key = keys.find(
+        (k) => k !== 'ctrl' && k !== 'alt' && k !== 'shift'
+      );
+      if (
+        key &&
+        e.key.toLowerCase() === key &&
+        e.ctrlKey === ctrl &&
+        e.altKey === alt &&
+        e.shiftKey === shift
+      ) {
+        e.preventDefault();
+        ref.current?.click();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [shortcut]);
+
+  const shortcutLabel = shortcut?.join('+');
+
+  return (
+    <MuiButton ref={ref} {...props}>
+      {shortcutLabel ? (
+        <>
+          {children} ({shortcutLabel})
+        </>
+      ) : (
+        children
+      )}
+    </MuiButton>
+  );
+};

--- a/src/Apps/erp/shared/components/components/Button.tsx
+++ b/src/Apps/erp/shared/components/components/Button.tsx
@@ -40,7 +40,7 @@ export const Button: React.FC<ShortcutButtonProps> = ({
     return () => window.removeEventListener('keydown', handler);
   }, [shortcut]);
 
-  const shortcutLabel = shortcut?.join('+');
+  const shortcutLabel = (shortcut ?? []).slice(1).join('+');
 
   return (
     <MuiButton ref={ref} {...props}>
@@ -49,7 +49,11 @@ export const Button: React.FC<ShortcutButtonProps> = ({
         <Typography
           variant="caption"
           component="span"
-          sx={{ ml: 1, opacity: 0.75 }}
+          sx={{
+            ml: 0.5,
+            opacity: 0.75,
+            fontSize: '0.45rem',
+          }}
         >
           ({shortcutLabel})
         </Typography>

--- a/src/Apps/erp/shared/components/components/Button.tsx
+++ b/src/Apps/erp/shared/components/components/Button.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import MuiButton, { ButtonProps } from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
 
 interface ShortcutButtonProps extends ButtonProps {
   shortcut?: string[];
@@ -13,9 +14,11 @@ export const Button: React.FC<ShortcutButtonProps> = ({
   const ref = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (!shortcut) return;
+    if (!shortcut || shortcut.length === 0) return;
     const handler = (e: KeyboardEvent) => {
-      const keys = shortcut.map((k) => k.toLowerCase());
+      const keys = shortcut
+        .filter((k): k is string => Boolean(k))
+        .map((k) => k.toLowerCase());
       const ctrl = keys.includes('ctrl');
       const alt = keys.includes('alt');
       const shift = keys.includes('shift');
@@ -41,12 +44,15 @@ export const Button: React.FC<ShortcutButtonProps> = ({
 
   return (
     <MuiButton ref={ref} {...props}>
-      {shortcutLabel ? (
-        <>
-          {children} ({shortcutLabel})
-        </>
-      ) : (
-        children
+      {children}
+      {shortcutLabel && (
+        <Typography
+          variant="caption"
+          component="span"
+          sx={{ ml: 1, opacity: 0.75 }}
+        >
+          ({shortcutLabel})
+        </Typography>
       )}
     </MuiButton>
   );

--- a/src/Apps/erp/shared/components/components/Checkbox.tsx
+++ b/src/Apps/erp/shared/components/components/Checkbox.tsx
@@ -17,7 +17,7 @@ export const Checkbox = <T extends FieldValues>({
   checkboxProps
 }: RHFCheckboxProps<T>) => (
   <Controller
-    name={name}
+    name={name as any}
     control={control}
     render={({ field }) => (
       <FormControlLabel

--- a/src/Apps/erp/shared/components/components/TextField.tsx
+++ b/src/Apps/erp/shared/components/components/TextField.tsx
@@ -16,9 +16,9 @@ export const TextField = <T extends FieldValues>({
   ...props
 }: RHFTextFieldProps<T>) => (
   <Controller
-    name={name}
+    name={name as any}
     control={control}
-    rules={rules}
+    rules={rules as any}
     render={({ field, fieldState: { error } }) => (
       <TextFieldMUI {...field} {...props} error={!!error} helperText={error?.message} />
     )}

--- a/src/Apps/erp/shared/components/components/tests/Button.test.tsx
+++ b/src/Apps/erp/shared/components/components/tests/Button.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '../Button';
+
+test('triggers click on shortcut and shows label', async () => {
+  const user = userEvent.setup();
+  const handleClick = jest.fn();
+  render(
+    <Button shortcut={['Ctrl', 'Enter']} onClick={handleClick}>
+      Save
+    </Button>
+  );
+  await user.keyboard('{Control>}{Enter}{/Control}');
+  expect(handleClick).toHaveBeenCalled();
+  expect(
+    screen.getByRole('button', { name: /Save \(Ctrl\+Enter\)/i })
+  ).toBeInTheDocument();
+});

--- a/src/Apps/erp/shared/components/components/tests/Checkbox.test.tsx
+++ b/src/Apps/erp/shared/components/components/tests/Checkbox.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm } from 'react-hook-form';
+import { Checkbox } from '../Checkbox';
+
+test('renders checkbox and toggles value', async () => {
+  const Wrapper = () => {
+    const { control } = useForm({ defaultValues: { remember: false } });
+    return <Checkbox name="remember" control={control} label="Remember" />;
+  };
+  const user = userEvent.setup();
+  render(<Wrapper />);
+  const checkbox = screen.getByLabelText('Remember');
+  expect(checkbox).not.toBeChecked();
+  await user.click(checkbox);
+  expect(checkbox).toBeChecked();
+});

--- a/src/Apps/erp/shared/components/components/tests/TextField.test.tsx
+++ b/src/Apps/erp/shared/components/components/tests/TextField.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm } from 'react-hook-form';
+import { TextField } from '../TextField';
+
+test('renders text field and updates value', async () => {
+  const Wrapper = () => {
+    const { control } = useForm({ defaultValues: { name: '' } });
+    return <TextField name="name" control={control} label="Name" />;
+  };
+  const user = userEvent.setup();
+  render(<Wrapper />);
+  const input = screen.getByLabelText('Name');
+  await user.type(input, 'John');
+  expect((input as HTMLInputElement).value).toBe('John');
+});


### PR DESCRIPTION
## Summary
- support keyboard shortcuts as key arrays on the reusable Button
- split login hook logic into session reducer and validation schema modules
- add tests for shared Button, Checkbox, and TextField components

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f24d0bec832092e972543c08a7e6