### PR TITLE
Add Razor Pages login interface for Sentinel service

### DIFF
--- a/src/Core/Services/Sentinel/Sentinel.Api/Pages/Login.cshtml
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Pages/Login.cshtml
@@ -1,0 +1,164 @@
+@page
+@model LoginModel
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8" />
+    <title>Login</title>
+    <style>
+        :root { --primary-blue: #1976d2; }
+        body {
+            margin: 0;
+            font-family: system-ui, sans-serif;
+            background: #ffffff;
+        }
+        .login-container {
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+        }
+        .login-card {
+            width: 420px;
+            max-width: 90vw;
+            padding: 32px;
+            border-radius: 12px;
+            box-shadow: 0 8px 24px rgba(0,0,0,.08);
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            background: #fff;
+        }
+        .logo {
+            display: flex;
+            justify-content: center;
+        }
+        .logo img {
+            height: 32px;
+        }
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+        label {
+            font-size: 14px;
+        }
+        input[type=text],
+        input[type=password] {
+            border: 1px solid #c4c4c4;
+            border-radius: 8px;
+            height: 48px;
+            padding: 12px 14px;
+            font-size: 16px;
+            width: 100%;
+            box-sizing: border-box;
+        }
+        input:focus {
+            outline: none;
+            border-color: var(--primary-blue);
+            box-shadow: 0 0 0 2px rgba(25,118,210,.2);
+        }
+        .password-wrapper {
+            position: relative;
+        }
+        .password-wrapper button {
+            position: absolute;
+            right: 10px;
+            top: 50%;
+            transform: translateY(-50%);
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            padding: 4px;
+        }
+        .password-wrapper button:focus {
+            outline: 2px solid var(--primary-blue);
+            border-radius: 4px;
+        }
+        .submit-btn {
+            background: var(--primary-blue);
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            height: 48px;
+            width: 100%;
+            text-transform: uppercase;
+            font-weight: 600;
+            font-size: 16px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+        }
+        .submit-btn:hover {
+            background: #155a9c;
+        }
+        .submit-btn:disabled {
+            opacity: .6;
+            cursor: default;
+        }
+        .submit-btn .caption {
+            font-size: 12px;
+        }
+        .forgot-link {
+            display: block;
+            text-align: center;
+            font-size: 14px;
+            color: var(--primary-blue);
+            text-decoration: underline;
+        }
+        .forgot-link:focus {
+            outline: 2px solid var(--primary-blue);
+        }
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            line-height: 1.4;
+            color: #555;
+        }
+        .footer a {
+            color: var(--primary-blue);
+        }
+        .footer a:focus {
+            outline: 2px solid var(--primary-blue);
+        }
+    </style>
+</head>
+<body>
+<main class="login-container">
+    <form method="post" novalidate class="login-card">
+        @Html.AntiForgeryToken()
+        <div class="logo">
+            <img src="/logo.png" alt="Logo do cliente" />
+        </div>
+        <div class="form-group">
+            <label for="Username">Usuário</label>
+            <input type="text" id="Username" name="Username" autocomplete="username" value="@Model.Username" />
+        </div>
+        <div class="form-group password-wrapper">
+            <label for="Password">Senha</label>
+            <input type="password" id="Password" name="Password" autocomplete="current-password" />
+            <button type="button" id="togglePassword" aria-label="Mostrar senha">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+            </button>
+        </div>
+        <button type="submit" class="submit-btn">ENTRAR <span class="caption">(ENTER)</span></button>
+        <a href="#" class="forgot-link">Esqueci minha senha</a>
+        <div class="footer">
+            <p>Desenvolvido por <a href="https://cardapius.com.br" target="_blank" rel="noopener">Cardapius</a></p>
+            <p>suporte@cardapius.com.br<br />(45) 99934-2864</p>
+        </div>
+    </form>
+</main>
+<script>
+    const togglePassword = document.getElementById('togglePassword');
+    const passwordInput = document.getElementById('Password');
+    togglePassword.addEventListener('click', () => {
+        const isPassword = passwordInput.type === 'password';
+        passwordInput.type = isPassword ? 'text' : 'password';
+        togglePassword.setAttribute('aria-label', isPassword ? 'Ocultar senha' : 'Mostrar senha');
+    });
+</script>
+</body>
+</html>

--- a/src/Core/Services/Sentinel/Sentinel.Api/Pages/Login.cshtml.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Pages/Login.cshtml.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Sentinel.Api.Pages;
+
+public class LoginModel : PageModel
+{
+    [BindProperty]
+    [Required]
+    public string Username { get; set; } = "administrador";
+
+    [BindProperty]
+    [Required]
+    public string Password { get; set; } = string.Empty;
+
+    public void OnGet()
+    {
+    }
+
+    public void OnPost()
+    {
+        if (ModelState.IsValid)
+        {
+            ModelState.AddModelError(string.Empty, "Credenciais inválidas (demo)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add standalone Razor Pages login screen with Portuguese labels, password visibility toggle, and accessibility enhancements
- Provide PageModel with validation and demo error handling

## Testing
- `dotnet test src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689be41dc3448320b731234e6f5d025f