### PR TITLE
Refactor login flow to use Razor views and add logout

### DIFF
--- a/src/Core/Services/Sentinel/Sentinel.Api/ViewModels/LoginModel.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/ViewModels/LoginModel.cs
@@ -1,9 +1,16 @@
-﻿namespace Sentinel.Api.ViewModels
+using System.ComponentModel.DataAnnotations;
+
+namespace Sentinel.Api.ViewModels;
+
+public class LoginModel
 {
-    public class LoginModel
-    {
-        public string Username { get; set; }
-        public string Password { get; set; }
-        public string? ReturnUrl { get; internal set; }
-    }
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+
+    public string? ReturnUrl { get; set; }
 }
+

--- a/src/Core/Services/Sentinel/Sentinel.Api/Views/Account/Login.cshtml
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Views/Account/Login.cshtml
@@ -150,22 +150,25 @@
 </head>
 <body>
     <main class="login-container">
-        <form method="post" novalidate class="login-card">
-            <input type='hidden' name='returnUrl' value='{returnUrl}' />
+        <form asp-action="Login" method="post" novalidate class="login-card">
+            <input asp-for="ReturnUrl" type="hidden" />
             @Html.AntiForgeryToken()
             <div class="logo">
                 <img src="/logo.png" alt="Logo do cliente" />
             </div>
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
-                <label for="Username">Usuário</label>
-                <input type="text" id="Username" name="Username" autocomplete="username" value="@Model.Username" />
+                <label asp-for="Email"></label>
+                <input asp-for="Email" type="email" autocomplete="username" />
+                <span asp-validation-for="Email" class="text-danger"></span>
             </div>
             <div class="form-group password-wrapper">
-                <label for="Password">Senha</label>
-                <input type="password" id="Password" name="Password" autocomplete="current-password" />
+                <label asp-for="Password"></label>
+                <input asp-for="Password" autocomplete="current-password" />
                 <button type="button" id="togglePassword" aria-label="Mostrar senha">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
                 </button>
+                <span asp-validation-for="Password" class="text-danger"></span>
             </div>
             <button type="submit" class="submit-btn">ENTRAR <span class="caption">(ENTER)</span></button>
             <a href="#" class="forgot-link">Esqueci minha senha</a>

--- a/src/Core/Services/Sentinel/Sentinel.Api/Views/_ViewImports.cshtml
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+


### PR DESCRIPTION
## Summary
- Refactor AccountController to return Razor views, surface validation errors and support logout
- Add LoginModel with data annotations for email/password and integrate with view
- Improve login view with tag helpers and validation UI, plus add view imports

## Testing
- `dotnet build Cardapius.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d1923752c83209770c1501c40218f