### PR TITLE
feat: add global error page

### DIFF
--- a/src/Core/Services/Sentinel/Sentinel.Api/Controllers/AuthorizationController.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Controllers/AuthorizationController.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using Sentinel.Api.Models;
+using System.Security.Claims;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Sentinel.Api.Controllers;
 
@@ -12,11 +15,35 @@ public class AuthorizationController : Controller
 {
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IConfiguration _configuration;
+    private static readonly string[] DefaultAllowedScopes =
+    {
+        OpenIddictConstants.Scopes.Email,
+        OpenIddictConstants.Scopes.Profile,
+        OpenIddictConstants.Scopes.OpenId,
+        OpenIddictConstants.Scopes.OfflineAccess,
+        "api"
+    };
 
-    public AuthorizationController(SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager)
+    public AuthorizationController(
+        SignInManager<ApplicationUser> signInManager,
+        UserManager<ApplicationUser> userManager,
+        IConfiguration configuration)
     {
         _signInManager = signInManager;
         _userManager = userManager;
+        _configuration = configuration;
+    }
+
+    private string[] GetAllowedScopes(string? clientId)
+    {
+        if (string.IsNullOrEmpty(clientId))
+        {
+            return DefaultAllowedScopes;
+        }
+
+        var scopes = _configuration.GetSection($"Clients:{clientId}:AllowedScopes").Get<string[]>() ?? [];
+        return scopes.Length > 0 ? scopes : DefaultAllowedScopes;
     }
 
     [IgnoreAntiforgeryToken]
@@ -34,7 +61,8 @@ public class AuthorizationController : Controller
         }
 
         var user = await _userManager.GetUserAsync(User);
-        if (user is null || !user.IsActive || (user.AccessGrantedUntil.HasValue && user.AccessGrantedUntil < DateTime.UtcNow))
+        if (user is null || !user.IsActive || (user.AccessGrantedUntil.HasValue && user.AccessGrantedUntil < DateTime.UtcNow)
+            || !await _signInManager.CanSignInAsync(user))
         {
             await _signInManager.SignOutAsync();
             return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
@@ -42,8 +70,9 @@ public class AuthorizationController : Controller
 
         var principal = await _signInManager.CreateUserPrincipalAsync(user);
         principal.SetClaim(OpenIddictConstants.Claims.Subject, user.Id);
-        principal.SetScopes(request.GetScopes());
-        foreach (var claim in principal.Claims)
+        var scopes = request.GetScopes().Intersect(GetAllowedScopes(request.ClientId));
+        principal.SetScopes(scopes);
+        foreach (var claim in principal.Claims.Where(c => c.Type != ClaimTypes.SecurityStamp))
         {
             claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken, OpenIddictConstants.Destinations.IdentityToken);
         }

--- a/src/Core/Services/Sentinel/Sentinel.Api/Controllers/ErrorController.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Controllers/ErrorController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sentinel.Api.Controllers;
+
+[ApiExplorerSettings(IgnoreApi = true)]
+public class ErrorController : Controller
+{
+    [Route("error")]
+    public IActionResult Error()
+    {
+        return View("Index");
+    }
+
+    [Route("error/{statusCode:int}")]
+    public IActionResult Error(int statusCode)
+    {
+        Response.StatusCode = statusCode;
+        return View("Index", statusCode);
+    }
+}

--- a/src/Core/Services/Sentinel/Sentinel.Api/Controllers/TokenController.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Controllers/TokenController.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using Sentinel.Api.Models;
+using System.Security.Claims;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Sentinel.Api.Controllers;
 
@@ -12,11 +15,35 @@ public class TokenController : Controller
 {
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IConfiguration _configuration;
+    private static readonly string[] DefaultAllowedScopes =
+    {
+        OpenIddictConstants.Scopes.Email,
+        OpenIddictConstants.Scopes.Profile,
+        OpenIddictConstants.Scopes.OpenId,
+        OpenIddictConstants.Scopes.OfflineAccess,
+        "api"
+    };
 
-    public TokenController(SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager)
+    public TokenController(
+        SignInManager<ApplicationUser> signInManager,
+        UserManager<ApplicationUser> userManager,
+        IConfiguration configuration)
     {
         _signInManager = signInManager;
         _userManager = userManager;
+        _configuration = configuration;
+    }
+
+    private string[] GetAllowedScopes(string? clientId)
+    {
+        if (string.IsNullOrEmpty(clientId))
+        {
+            return DefaultAllowedScopes;
+        }
+
+        var scopes = _configuration.GetSection($"Clients:{clientId}:AllowedScopes").Get<string[]>() ?? [];
+        return scopes.Length > 0 ? scopes : DefaultAllowedScopes;
     }
 
     [IgnoreAntiforgeryToken]
@@ -40,15 +67,16 @@ public class TokenController : Controller
             }
 
             var result = await _signInManager.CheckPasswordSignInAsync(user, request.Password!, true);
-            if (!result.Succeeded)
+            if (!result.Succeeded || !await _signInManager.CanSignInAsync(user))
             {
                 return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
             }
 
             var principal = await _signInManager.CreateUserPrincipalAsync(user);
             principal.SetClaim(OpenIddictConstants.Claims.Subject, user.Id);
-            principal.SetScopes(request.GetScopes());
-            foreach (var claim in principal.Claims)
+            var scopes = request.GetScopes().Intersect(GetAllowedScopes(request.ClientId));
+            principal.SetScopes(scopes);
+            foreach (var claim in principal.Claims.Where(c => c.Type != ClaimTypes.SecurityStamp))
             {
                 claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken, OpenIddictConstants.Destinations.IdentityToken);
             }
@@ -75,7 +103,8 @@ public class TokenController : Controller
                 return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
             }
 
-            foreach (var claim in principal.Claims)
+            principal.SetScopes(principal.GetScopes().Intersect(GetAllowedScopes(request.ClientId)));
+            foreach (var claim in principal.Claims.Where(c => c.Type != ClaimTypes.SecurityStamp))
                 claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken,
                                       OpenIddictConstants.Destinations.IdentityToken);
 

--- a/src/Core/Services/Sentinel/Sentinel.Api/Data/Seeds/ClientSeedService.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Data/Seeds/ClientSeedService.cs
@@ -1,18 +1,36 @@
-﻿
 using OpenIddict.Abstractions;
+using Microsoft.Extensions.Configuration;
 
 namespace Sentinel.Api.Data.Seeds
 {
-    public class ClientSeedService(IOpenIddictApplicationManager manager) : ISeedService
+    public class ClientSeedService(IOpenIddictApplicationManager manager, IConfiguration configuration) : ISeedService
     {
+        private static readonly string[] DefaultAllowedScopes =
+        {
+            OpenIddictConstants.Scopes.Email,
+            OpenIddictConstants.Scopes.Profile,
+            OpenIddictConstants.Scopes.OpenId,
+            OpenIddictConstants.Scopes.OfflineAccess,
+            "api"
+        };
+
         public async Task SeedAsync()
         {
+            var consoleSection = configuration.GetSection("Clients:Console");
+            var clientSecret = consoleSection["Secret"];
+            if (string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new InvalidOperationException("Client secret for 'console' is not configured.");
+            }
+
+            var allowedScopes = consoleSection.GetSection("AllowedScopes").Get<string[]>() ?? DefaultAllowedScopes;
+
             if (await manager.FindByClientIdAsync("console") is null)
             {
-                await manager.CreateAsync(new OpenIddictApplicationDescriptor
+                var descriptor = new OpenIddictApplicationDescriptor
                 {
                     ClientId = "console",
-                    ClientSecret = "secret",
+                    ClientSecret = clientSecret,
                     Permissions =
                     {
                         OpenIddictConstants.Permissions.Endpoints.Authorization,
@@ -20,15 +38,17 @@ namespace Sentinel.Api.Data.Seeds
                         OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
                         OpenIddictConstants.Permissions.ResponseTypes.Code,
                         OpenIddictConstants.Permissions.GrantTypes.ClientCredentials,
-                        OpenIddictConstants.Permissions.GrantTypes.Password,
-                        OpenIddictConstants.Permissions.Scopes.Email,
-                        OpenIddictConstants.Permissions.Scopes.Profile,
-                        OpenIddictConstants.Scopes.OpenId,
-                        OpenIddictConstants.Scopes.OfflineAccess,
-                        OpenIddictConstants.Permissions.Prefixes.Scope + "api"
+                        OpenIddictConstants.Permissions.GrantTypes.Password
                     },
                     RedirectUris = { new Uri("https://localhost:5001/swagger/oauth2-redirect.html") },
-                });
+                };
+
+                foreach (var scope in allowedScopes)
+                {
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.Prefixes.Scope + scope);
+                }
+
+                await manager.CreateAsync(descriptor);
             }
         }
     }

--- a/src/Core/Services/Sentinel/Sentinel.Api/Program.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Program.cs
@@ -26,6 +26,8 @@ var app = builder.Build();
 
 app.UseAppLogging();
 app.UseCors(policy => policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
+app.UseExceptionHandler("/error");
+app.UseStatusCodePagesWithReExecute("/error/{0}");
 app.UseCorrelationId();
 app.UseAppRateLimiter();
 app.UseRouting();

--- a/src/Core/Services/Sentinel/Sentinel.Api/Views/Error/Index.cshtml
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Views/Error/Index.cshtml
@@ -1,0 +1,23 @@
+@model int?
+
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8" />
+    <title>Erro</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <link rel="stylesheet" href="~/css/error/index.css" />
+</head>
+<body>
+    <main class="error-container">
+        <div class="error-card">
+            <h1>Ocorreu um erro</h1>
+            @if (Model.HasValue)
+            {
+                <p>Código: @Model</p>
+            }
+            <p>Tente novamente mais tarde.</p>
+        </div>
+    </main>
+</body>
+</html>

--- a/src/Core/Services/Sentinel/Sentinel.Api/appsettings.json
+++ b/src/Core/Services/Sentinel/Sentinel.Api/appsettings.json
@@ -13,6 +13,18 @@
       "Administration.Viewer"
     ]
   },
+  "Clients": {
+    "Console": {
+      "Secret": "change-me",
+      "AllowedScopes": [
+        "email",
+        "profile",
+        "openid",
+        "offline_access",
+        "api"
+      ]
+    }
+  },
   "Serilog": {
     "MinimumLevel": "Information",
     "WriteTo": [

--- a/src/Core/Services/Sentinel/Sentinel.Api/wwwroot/css/error/index.css
+++ b/src/Core/Services/Sentinel/Sentinel.Api/wwwroot/css/error/index.css
@@ -1,0 +1,19 @@
+.error-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background-color: #f5f5f5;
+}
+
+.error-card {
+    text-align: center;
+    padding: 2rem;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.error-card h1 {
+    color: #c00;
+}

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/ErrorControllerTests.cs
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/ErrorControllerTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Sentinel.Api.Controllers;
+
+public class ErrorControllerTests
+{
+    [Fact]
+    public void Error_ReturnsView()
+    {
+        var controller = new ErrorController();
+        var result = controller.Error() as ViewResult;
+        result.Should().NotBeNull();
+        result!.ViewName.Should().Be("Index");
+    }
+
+    [Fact]
+    public void Error_WithStatusCode_SetsStatusCode()
+    {
+        var controller = new ErrorController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        var result = controller.Error(404) as ViewResult;
+        result.Should().NotBeNull();
+        controller.Response.StatusCode.Should().Be(404);
+    }
+}

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Adapters\Driving\Sentinel.Api\Sentinel.Api.csproj" />
+    <ProjectReference Include="..\Sentinel.Api\Sentinel.Api.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
## Summary
- route client and server failures to a shared error page
- add MVC error view and styling
- cover error handling with unit tests and fix project reference
- restrict OpenIddict scopes and move client secret to configuration
- load allowed scopes from per-client configuration and seed permissions accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fc180b3483208e8338f7807bb172