### PR TITLE
feat: add global error page and token lifetime settings

### DIFF
--- a/src/Core/Services/Sentinel/Sentinel.Api/Controllers/AuthorizationController.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Controllers/AuthorizationController.cs
@@ -1,29 +1,19 @@
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
-using Sentinel.Api.Models;
+using Sentinel.Api.Services;
 
 namespace Sentinel.Api.Controllers;
 
-public class AuthorizationController : Controller
+public class AuthorizationController(IUserTokenService tokenService) : Controller
 {
-    private readonly SignInManager<ApplicationUser> _signInManager;
-    private readonly UserManager<ApplicationUser> _userManager;
-
-    public AuthorizationController(SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager)
-    {
-        _signInManager = signInManager;
-        _userManager = userManager;
-    }
-
     [IgnoreAntiforgeryToken]
     [HttpGet("~/connect/authorize")]
     public async Task<IActionResult> Authorize()
     {
-        var request = HttpContext.GetOpenIddictServerRequest() ?? throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
+        var request = HttpContext.GetOpenIddictServerRequest() ??
+                      throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
 
         if (!User.Identity?.IsAuthenticated ?? true)
         {
@@ -33,21 +23,14 @@ public class AuthorizationController : Controller
             });
         }
 
-        var user = await _userManager.GetUserAsync(User);
-        if (user is null || !user.IsActive || (user.AccessGrantedUntil.HasValue && user.AccessGrantedUntil < DateTime.UtcNow))
+        var user = await tokenService.ValidateUserAsync(User);
+        if (user is null)
         {
-            await _signInManager.SignOutAsync();
+            await tokenService.SignOutAsync();
             return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 
-        var principal = await _signInManager.CreateUserPrincipalAsync(user);
-        principal.SetClaim(OpenIddictConstants.Claims.Subject, user.Id);
-        principal.SetScopes(request.GetScopes());
-        foreach (var claim in principal.Claims)
-        {
-            claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken, OpenIddictConstants.Destinations.IdentityToken);
-        }
-
+        var principal = await tokenService.CreatePrincipalAsync(user, request.GetScopes(), request.ClientId);
         return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }
 }

--- a/src/Core/Services/Sentinel/Sentinel.Api/Controllers/ErrorController.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Controllers/ErrorController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sentinel.Api.Controllers;
+
+[ApiExplorerSettings(IgnoreApi = true)]
+public class ErrorController : Controller
+{
+    [Route("error")]
+    public IActionResult Error()
+    {
+        return View("Index");
+    }
+
+    [Route("error/{statusCode:int}")]
+    public IActionResult Error(int statusCode)
+    {
+        Response.StatusCode = statusCode;
+        return View("Index", statusCode);
+    }
+}

--- a/src/Core/Services/Sentinel/Sentinel.Api/Controllers/TokenController.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Controllers/TokenController.cs
@@ -1,24 +1,13 @@
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
-using Sentinel.Api.Models;
+using Sentinel.Api.Services;
 
 namespace Sentinel.Api.Controllers;
 
-public class TokenController : Controller
+public class TokenController(IUserTokenService tokenService) : Controller
 {
-    private readonly SignInManager<ApplicationUser> _signInManager;
-    private readonly UserManager<ApplicationUser> _userManager;
-
-    public TokenController(SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager)
-    {
-        _signInManager = signInManager;
-        _userManager = userManager;
-    }
-
     [IgnoreAntiforgeryToken]
     [HttpPost("~/connect/token")]
     public async Task<IActionResult> Exchange()
@@ -26,60 +15,32 @@ public class TokenController : Controller
         var request = HttpContext.GetOpenIddictServerRequest() ??
                       throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
 
-        if (request.GrantType == OpenIddictConstants.GrantTypes.Password)
+        switch (request.GrantType)
         {
-            var user = await _userManager.FindByNameAsync(request.Username);
-            if (user is null)
+            case OpenIddictConstants.GrantTypes.Password:
             {
-                return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-            }
+                var user = await tokenService.ValidateUserAsync(request.Username!, request.Password!);
+                if (user is null)
+                    return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
 
-            if (!user.IsActive || (user.AccessGrantedUntil.HasValue && user.AccessGrantedUntil < DateTime.UtcNow))
+                var principal = await tokenService.CreatePrincipalAsync(user, request.GetScopes(), request.ClientId);
+                return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+            }
+            case OpenIddictConstants.GrantTypes.AuthorizationCode:
+            case OpenIddictConstants.GrantTypes.RefreshToken:
             {
-                return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+                var authenticateResult = await HttpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+                var principal = authenticateResult?.Principal;
+                if (principal is null)
+                    return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+
+                var user = await tokenService.ValidateUserAsync(principal);
+                if (user is null)
+                    return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+
+                var newPrincipal = await tokenService.CreatePrincipalAsync(user, principal.GetScopes(), request.ClientId);
+                return SignIn(newPrincipal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
             }
-
-            var result = await _signInManager.CheckPasswordSignInAsync(user, request.Password!, true);
-            if (!result.Succeeded)
-            {
-                return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-            }
-
-            var principal = await _signInManager.CreateUserPrincipalAsync(user);
-            principal.SetClaim(OpenIddictConstants.Claims.Subject, user.Id);
-            principal.SetScopes(request.GetScopes());
-            foreach (var claim in principal.Claims)
-            {
-                claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken, OpenIddictConstants.Destinations.IdentityToken);
-            }
-
-            return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-        }
-        else if (request.GrantType is OpenIddictConstants.GrantTypes.AuthorizationCode or OpenIddictConstants.GrantTypes.RefreshToken)
-        {
-            var authenticateResult = await HttpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-
-            var principal = authenticateResult?.Principal;
-            if (principal is null)
-                return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-
-            var userId = principal.GetClaim(OpenIddictConstants.Claims.Subject);
-            if (string.IsNullOrEmpty(userId))
-                return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-
-            var user = await _userManager.FindByIdAsync(userId);
-            if (user is null || !user.IsActive
-                || (user.AccessGrantedUntil.HasValue && user.AccessGrantedUntil < DateTime.UtcNow)
-                || !await _signInManager.CanSignInAsync(user))
-            {
-                return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-            }
-
-            foreach (var claim in principal.Claims)
-                claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken,
-                                      OpenIddictConstants.Destinations.IdentityToken);
-
-            return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 
         throw new InvalidOperationException("The specified grant type is not supported.");

--- a/src/Core/Services/Sentinel/Sentinel.Api/Data/Seeds/ClientSeedService.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Data/Seeds/ClientSeedService.cs
@@ -1,18 +1,36 @@
-﻿
 using OpenIddict.Abstractions;
+using Microsoft.Extensions.Configuration;
 
 namespace Sentinel.Api.Data.Seeds
 {
-    public class ClientSeedService(IOpenIddictApplicationManager manager) : ISeedService
+    public class ClientSeedService(IOpenIddictApplicationManager manager, IConfiguration configuration) : ISeedService
     {
+        private static readonly string[] DefaultAllowedScopes =
+        {
+            OpenIddictConstants.Scopes.Email,
+            OpenIddictConstants.Scopes.Profile,
+            OpenIddictConstants.Scopes.OpenId,
+            OpenIddictConstants.Scopes.OfflineAccess,
+            "api"
+        };
+
         public async Task SeedAsync()
         {
+            var consoleSection = configuration.GetSection("Clients:Console");
+            var clientSecret = consoleSection["Secret"];
+            if (string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new InvalidOperationException("Client secret for 'console' is not configured.");
+            }
+
+            var allowedScopes = consoleSection.GetSection("AllowedScopes").Get<string[]>() ?? DefaultAllowedScopes;
+
             if (await manager.FindByClientIdAsync("console") is null)
             {
-                await manager.CreateAsync(new OpenIddictApplicationDescriptor
+                var descriptor = new OpenIddictApplicationDescriptor
                 {
                     ClientId = "console",
-                    ClientSecret = "secret",
+                    ClientSecret = clientSecret,
                     Permissions =
                     {
                         OpenIddictConstants.Permissions.Endpoints.Authorization,
@@ -20,15 +38,17 @@ namespace Sentinel.Api.Data.Seeds
                         OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
                         OpenIddictConstants.Permissions.ResponseTypes.Code,
                         OpenIddictConstants.Permissions.GrantTypes.ClientCredentials,
-                        OpenIddictConstants.Permissions.GrantTypes.Password,
-                        OpenIddictConstants.Permissions.Scopes.Email,
-                        OpenIddictConstants.Permissions.Scopes.Profile,
-                        OpenIddictConstants.Scopes.OpenId,
-                        OpenIddictConstants.Scopes.OfflineAccess,
-                        OpenIddictConstants.Permissions.Prefixes.Scope + "api"
+                        OpenIddictConstants.Permissions.GrantTypes.Password
                     },
                     RedirectUris = { new Uri("https://localhost:5001/swagger/oauth2-redirect.html") },
-                });
+                };
+
+                foreach (var scope in allowedScopes)
+                {
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.Prefixes.Scope + scope);
+                }
+
+                await manager.CreateAsync(descriptor);
             }
         }
     }

--- a/src/Core/Services/Sentinel/Sentinel.Api/Extensions/AuthenticationExtensions.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Extensions/AuthenticationExtensions.cs
@@ -29,8 +29,20 @@ namespace Sentinel.Api.Extensions
                        .AcceptAnonymousClients()
                        .RequireProofKeyForCodeExchange()
                        .AddDevelopmentEncryptionCertificate()
-                       .AddDevelopmentSigningCertificate()
-                       .UseAspNetCore()
+                       .AddDevelopmentSigningCertificate();
+
+                    var lifetimes = configuration.GetSection("OpenIddict:TokenLifetimes");
+                    var access = lifetimes.GetValue<int?>("AccessToken");
+                    if (access.HasValue)
+                        opt.SetAccessTokenLifetime(TimeSpan.FromMinutes(access.Value));
+                    var refresh = lifetimes.GetValue<int?>("RefreshToken");
+                    if (refresh.HasValue)
+                        opt.SetRefreshTokenLifetime(TimeSpan.FromMinutes(refresh.Value));
+                    var code = lifetimes.GetValue<int?>("AuthorizationCode");
+                    if (code.HasValue)
+                        opt.SetAuthorizationCodeLifetime(TimeSpan.FromMinutes(code.Value));
+
+                    opt.UseAspNetCore()
                            .EnableAuthorizationEndpointPassthrough()
                            .EnableTokenEndpointPassthrough();
                     //.EnableIntrospectionEndpointPassthrough()

--- a/src/Core/Services/Sentinel/Sentinel.Api/Extensions/InjectServicesExtensions.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Extensions/InjectServicesExtensions.cs
@@ -12,6 +12,9 @@ namespace Sentinel.Api.Extensions
             services.AddScoped<ISeedService, UserSeedService>();
             services.AddSingleton<PasswordGeneratorService>();
 
+            services.AddSingleton<IClientConfigurationService, ClientConfigurationService>();
+            services.AddScoped<IUserTokenService, UserTokenService>();
+
             services.AddHostedService<Worker>();
             return services;
         }

--- a/src/Core/Services/Sentinel/Sentinel.Api/Program.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Program.cs
@@ -26,6 +26,8 @@ var app = builder.Build();
 
 app.UseAppLogging();
 app.UseCors(policy => policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
+app.UseExceptionHandler("/error");
+app.UseStatusCodePagesWithReExecute("/error/{0}");
 app.UseCorrelationId();
 app.UseAppRateLimiter();
 app.UseRouting();

--- a/src/Core/Services/Sentinel/Sentinel.Api/Services/ClientConfigurationService.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Services/ClientConfigurationService.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Configuration;
+using OpenIddict.Abstractions;
+
+namespace Sentinel.Api.Services;
+
+public record TokenLifetimeOptions(TimeSpan? AccessToken, TimeSpan? RefreshToken, TimeSpan? AuthorizationCode);
+
+public interface IClientConfigurationService
+{
+    string[] GetAllowedScopes(string? clientId);
+    TokenLifetimeOptions GetTokenLifetimes(string? clientId);
+}
+
+public class ClientConfigurationService(IConfiguration configuration) : IClientConfigurationService
+{
+    private static readonly string[] DefaultAllowedScopes =
+    {
+        OpenIddictConstants.Scopes.Email,
+        OpenIddictConstants.Scopes.Profile,
+        OpenIddictConstants.Scopes.OpenId,
+        OpenIddictConstants.Scopes.OfflineAccess,
+        "api"
+    };
+
+    public string[] GetAllowedScopes(string? clientId)
+    {
+        if (string.IsNullOrEmpty(clientId))
+            return DefaultAllowedScopes;
+
+        var scopes = configuration.GetSection($"Clients:{clientId}:AllowedScopes").Get<string[]>() ?? Array.Empty<string>();
+        return scopes.Length > 0 ? scopes : DefaultAllowedScopes;
+    }
+
+    public TokenLifetimeOptions GetTokenLifetimes(string? clientId)
+    {
+        var defaults = configuration.GetSection("OpenIddict:TokenLifetimes");
+        var accessDefault = defaults.GetValue<int?>("AccessToken");
+        var refreshDefault = defaults.GetValue<int?>("RefreshToken");
+        var codeDefault = defaults.GetValue<int?>("AuthorizationCode");
+
+        var section = string.IsNullOrEmpty(clientId)
+            ? null
+            : configuration.GetSection($"Clients:{clientId}:TokenLifetimes");
+
+        var access = section?.GetValue<int?>("AccessToken") ?? accessDefault;
+        var refresh = section?.GetValue<int?>("RefreshToken") ?? refreshDefault;
+        var code = section?.GetValue<int?>("AuthorizationCode") ?? codeDefault;
+
+        return new TokenLifetimeOptions(ToMinutes(access), ToMinutes(refresh), ToMinutes(code));
+    }
+
+    private static TimeSpan? ToMinutes(int? value) => value.HasValue ? TimeSpan.FromMinutes(value.Value) : null;
+}

--- a/src/Core/Services/Sentinel/Sentinel.Api/Services/UserTokenService.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Services/UserTokenService.cs
@@ -1,0 +1,76 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using OpenIddict.Abstractions;
+using Sentinel.Api.Models;
+
+namespace Sentinel.Api.Services;
+
+public interface IUserTokenService
+{
+    Task<ApplicationUser?> ValidateUserAsync(string username, string password);
+    Task<ApplicationUser?> ValidateUserAsync(ClaimsPrincipal principal);
+    Task SignOutAsync();
+    Task<ClaimsPrincipal> CreatePrincipalAsync(ApplicationUser user, IEnumerable<string> requestedScopes, string? clientId);
+}
+
+public class UserTokenService(
+    SignInManager<ApplicationUser> signInManager,
+    UserManager<ApplicationUser> userManager,
+    IClientConfigurationService clientConfig) : IUserTokenService
+{
+    public async Task<ApplicationUser?> ValidateUserAsync(string username, string password)
+    {
+        var user = await userManager.FindByNameAsync(username);
+        if (user is null || !await IsValidAsync(user))
+            return null;
+
+        var result = await signInManager.CheckPasswordSignInAsync(user, password, true);
+        return result.Succeeded ? user : null;
+    }
+
+    public async Task<ApplicationUser?> ValidateUserAsync(ClaimsPrincipal principal)
+    {
+        var userId = principal.GetClaim(OpenIddictConstants.Claims.Subject);
+        if (string.IsNullOrEmpty(userId))
+            return null;
+
+        var user = await userManager.FindByIdAsync(userId);
+        return await IsValidAsync(user) ? user : null;
+    }
+
+    public Task SignOutAsync() => signInManager.SignOutAsync();
+
+    public async Task<ClaimsPrincipal> CreatePrincipalAsync(ApplicationUser user, IEnumerable<string> requestedScopes, string? clientId)
+    {
+        var principal = await signInManager.CreateUserPrincipalAsync(user);
+        principal.SetClaim(OpenIddictConstants.Claims.Subject, user.Id);
+
+        var allowedScopes = clientConfig.GetAllowedScopes(clientId);
+        var scopes = requestedScopes.Intersect(allowedScopes);
+        principal.SetScopes(scopes);
+
+        foreach (var claim in principal.Claims.Where(c => c.Type != ClaimTypes.SecurityStamp))
+        {
+            claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken,
+                                  OpenIddictConstants.Destinations.IdentityToken);
+        }
+
+        var lifetimes = clientConfig.GetTokenLifetimes(clientId);
+        if (lifetimes.AccessToken.HasValue)
+            principal.SetAccessTokenLifetime(lifetimes.AccessToken.Value);
+        if (lifetimes.RefreshToken.HasValue)
+            principal.SetRefreshTokenLifetime(lifetimes.RefreshToken.Value);
+        if (lifetimes.AuthorizationCode.HasValue)
+            principal.SetAuthorizationCodeLifetime(lifetimes.AuthorizationCode.Value);
+
+        return principal;
+    }
+
+    private async Task<bool> IsValidAsync(ApplicationUser? user)
+    {
+        return user is not null &&
+               user.IsActive &&
+               (!user.AccessGrantedUntil.HasValue || user.AccessGrantedUntil >= DateTime.UtcNow) &&
+               await signInManager.CanSignInAsync(user);
+    }
+}

--- a/src/Core/Services/Sentinel/Sentinel.Api/Views/Error/Index.cshtml
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Views/Error/Index.cshtml
@@ -1,0 +1,23 @@
+@model int?
+
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8" />
+    <title>Erro</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <link rel="stylesheet" href="~/css/error/index.css" />
+</head>
+<body>
+    <main class="error-container">
+        <div class="error-card">
+            <h1>Ocorreu um erro</h1>
+            @if (Model.HasValue)
+            {
+                <p>Código: @Model</p>
+            }
+            <p>Tente novamente mais tarde.</p>
+        </div>
+    </main>
+</body>
+</html>

--- a/src/Core/Services/Sentinel/Sentinel.Api/appsettings.json
+++ b/src/Core/Services/Sentinel/Sentinel.Api/appsettings.json
@@ -13,6 +13,30 @@
       "Administration.Viewer"
     ]
   },
+  "Clients": {
+    "Console": {
+      "Secret": "change-me",
+      "AllowedScopes": [
+        "email",
+        "profile",
+        "openid",
+        "offline_access",
+        "api"
+      ],
+      "TokenLifetimes": {
+        "AccessToken": 30,
+        "RefreshToken": 1440,
+        "AuthorizationCode": 1
+      }
+    }
+  },
+  "OpenIddict": {
+    "TokenLifetimes": {
+      "AccessToken": 60,
+      "RefreshToken": 43200,
+      "AuthorizationCode": 5
+    }
+  },
   "Serilog": {
     "MinimumLevel": "Information",
     "WriteTo": [

--- a/src/Core/Services/Sentinel/Sentinel.Api/wwwroot/css/error/index.css
+++ b/src/Core/Services/Sentinel/Sentinel.Api/wwwroot/css/error/index.css
@@ -1,0 +1,19 @@
+.error-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background-color: #f5f5f5;
+}
+
+.error-card {
+    text-align: center;
+    padding: 2rem;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.error-card h1 {
+    color: #c00;
+}

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/ClientConfigurationServiceTests.cs
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/ClientConfigurationServiceTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Sentinel.Api.Services;
+using Xunit;
+
+namespace Sentinel.Api.UnitTests;
+
+public class ClientConfigurationServiceTests
+{
+    [Fact]
+    public void GetTokenLifetimes_Returns_Client_Overrides()
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["OpenIddict:TokenLifetimes:AccessToken"] = "60",
+            ["OpenIddict:TokenLifetimes:RefreshToken"] = "120",
+            ["OpenIddict:TokenLifetimes:AuthorizationCode"] = "5",
+            ["Clients:console:TokenLifetimes:AccessToken"] = "30"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        var service = new ClientConfigurationService(configuration);
+
+        var lifetimes = service.GetTokenLifetimes("console");
+
+        Assert.Equal(TimeSpan.FromMinutes(30), lifetimes.AccessToken);
+        Assert.Equal(TimeSpan.FromMinutes(120), lifetimes.RefreshToken);
+        Assert.Equal(TimeSpan.FromMinutes(5), lifetimes.AuthorizationCode);
+    }
+}

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/ErrorControllerTests.cs
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/ErrorControllerTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Sentinel.Api.Controllers;
+
+public class ErrorControllerTests
+{
+    [Fact]
+    public void Error_ReturnsView()
+    {
+        var controller = new ErrorController();
+        var result = controller.Error() as ViewResult;
+        result.Should().NotBeNull();
+        result!.ViewName.Should().Be("Index");
+    }
+
+    [Fact]
+    public void Error_WithStatusCode_SetsStatusCode()
+    {
+        var controller = new ErrorController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        var result = controller.Error(404) as ViewResult;
+        result.Should().NotBeNull();
+        controller.Response.StatusCode.Should().Be(404);
+    }
+}

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Adapters\Driving\Sentinel.Api\Sentinel.Api.csproj" />
+    <ProjectReference Include="..\Sentinel.Api\Sentinel.Api.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
## Summary
- route client and server failures to a shared error page
- add MVC error view and styling
- cover error handling with unit tests and fix project reference
- restrict OpenIddict scopes and move client secret to configuration
- load allowed scopes from per-client configuration and seed permissions accordingly
- configure access, refresh and authorization code lifetimes through configuration
- rebuild user principal on refresh token requests to reload database roles
- centralize token issuance in a new service and allow per-client token lifetimes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.195 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68a0fc180b3483208e8338f7807bb172