### PR TITLE
test: cover user token service and adjust sonar exclusions

### DIFF
--- a/.github/workflows/dotnet-sonar.yaml
+++ b/.github/workflows/dotnet-sonar.yaml
@@ -34,7 +34,7 @@ jobs:
             /o:"evertonschuster-1" \
             /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.cs.opencover.reportsPaths="coverage-report/*.xml" \
-            /d:sonar.coverage.exclusions="**/*UnitTest*/**/*.cs,**/*Infra*/**/*.cs,**/*Api*/**/*.cs,**/.github/**" \
+            /d:sonar.coverage.exclusions="**/*UnitTest*/**/*.cs,**/*Infra*/**/*.cs,**/Migrations/**,**/Models/**,**/ViewModels/**,**/.github/**" \
             /d:sonar.projectBaseDir="$(pwd)"
 
       - name: Build solution

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/PasswordGeneratorServiceTests.cs
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/PasswordGeneratorServiceTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Sentinel.Api.Services;
+
+public class PasswordGeneratorServiceTests
+{
+    [Fact]
+    public void Generate_RespectsPasswordOptions()
+    {
+        var options = Options.Create(new PasswordOptions
+        {
+            RequiredLength = 10,
+            RequireDigit = true,
+            RequireLowercase = true,
+            RequireUppercase = true,
+            RequireNonAlphanumeric = true,
+            RequiredUniqueChars = 4
+        });
+
+        var service = new PasswordGeneratorService(options);
+        var password = service.Generate();
+
+        password.Length.Should().BeGreaterOrEqualTo(10);
+        password.Any(char.IsUpper).Should().BeTrue();
+        password.Any(char.IsLower).Should().BeTrue();
+        password.Any(char.IsDigit).Should().BeTrue();
+        password.Any(ch => "!@#$%^&*()-_=+[]{};:,.<>?".Contains(ch)).Should().BeTrue();
+        password.Distinct().Count().Should().BeGreaterOrEqualTo(4);
+    }
+
+    [Fact]
+    public void Generate_UsesMinLengthAndAllowedSymbols()
+    {
+        var options = Options.Create(new PasswordOptions
+        {
+            RequiredLength = 6,
+            RequireDigit = false,
+            RequireLowercase = false,
+            RequireUppercase = false,
+            RequireNonAlphanumeric = true
+        });
+
+        var service = new PasswordGeneratorService(options);
+        var password = service.Generate(minLength: 20, allowedSymbols: "*");
+
+        password.Length.Should().Be(20);
+        password.All(ch => ch == '*').Should().BeTrue();
+    }
+}

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Moq" Version="4.20.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/UserTokenServiceTests.cs
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/UserTokenServiceTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Moq;
+using OpenIddict.Abstractions;
+using Sentinel.Api.Models;
+using Sentinel.Api.Services;
+using System.Security.Claims;
+
+public class UserTokenServiceTests
+{
+    private static (UserTokenService Service, Mock<UserManager<ApplicationUser>> UserManager, Mock<SignInManager<ApplicationUser>> SignInManager) CreateService()
+    {
+        var userStore = new Mock<IUserStore<ApplicationUser>>();
+        var userManager = new Mock<UserManager<ApplicationUser>>(userStore.Object, null, null, null, null, null, null, null, null);
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>();
+        var signInManager = new Mock<SignInManager<ApplicationUser>>(userManager.Object, contextAccessor.Object, claimsFactory.Object, Options.Create(new IdentityOptions()), null, null, null);
+        var options = Options.Create(new IdentityOptions());
+        var service = new UserTokenService(signInManager.Object, userManager.Object, options);
+        return (service, userManager, signInManager);
+    }
+
+    [Fact]
+    public async Task ValidateUserAsync_ReturnsUser_WhenCredentialsValidAndUserActive()
+    {
+        var (service, userManager, signInManager) = CreateService();
+        var user = new ApplicationUser { UserName = "user", IsActive = true, AccessGrantedUntil = DateTime.UtcNow.AddDays(1) };
+
+        userManager.Setup(x => x.FindByNameAsync("user")).ReturnsAsync(user);
+        signInManager.Setup(x => x.CanSignInAsync(user)).ReturnsAsync(true);
+        signInManager.Setup(x => x.CheckPasswordSignInAsync(user, "pass", true)).ReturnsAsync(SignInResult.Success);
+
+        var result = await service.ValidateUserAsync("user", "pass");
+
+        result.Should().Be(user);
+    }
+
+    [Fact]
+    public async Task ValidateUserAsync_ReturnsNull_WhenUserInactive()
+    {
+        var (service, userManager, signInManager) = CreateService();
+        var user = new ApplicationUser { UserName = "user", IsActive = false };
+
+        userManager.Setup(x => x.FindByNameAsync("user")).ReturnsAsync(user);
+        signInManager.Setup(x => x.CanSignInAsync(user)).ReturnsAsync(true);
+
+        var result = await service.ValidateUserAsync("user", "pass");
+
+        result.Should().BeNull();
+        signInManager.Verify(x => x.CheckPasswordSignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), true), Times.Never);
+    }
+
+    [Fact]
+    public async Task SignOutAsync_InvokesSignInManager()
+    {
+        var (service, _, signInManager) = CreateService();
+        signInManager.Setup(x => x.SignOutAsync()).Returns(Task.CompletedTask).Verifiable();
+
+        await service.SignOutAsync();
+
+        signInManager.Verify(x => x.SignOutAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreatePrincipalAsync_SetsSubjectAndScopes()
+    {
+        var (service, _, signInManager) = CreateService();
+        var user = new ApplicationUser { Id = "123" };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("type", "value") }));
+        signInManager.Setup(x => x.CreateUserPrincipalAsync(user)).ReturnsAsync(principal);
+
+        var result = await service.CreatePrincipalAsync(user, new[] { "email", "profile" }, "client");
+
+        result.Should().BeSameAs(principal);
+        result.FindFirst(OpenIddictConstants.Claims.Subject)!.Value.Should().Be("123");
+        result.GetScopes().Should().BeEquivalentTo(new[] { "email", "profile" });
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for UserTokenService covering user validation, sign-out, and principal creation
- add Moq dependency for mocking identity services
- narrow Sonar coverage exclusions to models, view models, and migrations

## Testing
- `dotnet test src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj --collect:"XPlat Code Coverage"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27210ff3c8320aca61527e595bacf