### PR TITLE
feat: add OIDC auth provider and role hook

### DIFF
--- a/src/Apps/cardapius.restaurant.app/package.json
+++ b/src/Apps/cardapius.restaurant.app/package.json
@@ -14,6 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "oidc-client-ts": "^2.2.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/Apps/cardapius.restaurant.app/src/index.tsx
+++ b/src/Apps/cardapius.restaurant.app/src/index.tsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './main/Index';
 import reportWebVitals from './reportWebVitals';
+import { AuthProvider } from './shared/auth';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );
 

--- a/src/Apps/cardapius.restaurant.app/src/shared/auth/AuthProvider.tsx
+++ b/src/Apps/cardapius.restaurant.app/src/shared/auth/AuthProvider.tsx
@@ -24,16 +24,18 @@ const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
-  const [userManager] = useState(
+  const userManager = useMemo(
     () =>
       new UserManager({
         client_id: process.env.REACT_APP_OIDC_CLIENT_ID || '',
         authority: process.env.REACT_APP_OIDC_AUTHORITY || '',
         redirect_uri: window.location.origin + '/callback',
         silent_redirect_uri: window.location.origin + '/silent-renew',
+        post_logout_redirect_uri: window.location.origin + '/login',
         scope: process.env.REACT_APP_OIDC_SCOPE || 'openid profile',
         response_type: 'code',
       }),
+    [],
   );
 
   const [user, setUser] = useState<User | null>(null);
@@ -90,6 +92,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
   const signin = () => userManager.signinRedirect();
   const signout = () => {
     localStorage.setItem('logout', Date.now().toString());
+    setUser(null);
     return userManager.signoutRedirect();
   };
   const refresh = () => userManager.signinSilent();

--- a/src/Apps/cardapius.restaurant.app/src/shared/auth/AuthProvider.tsx
+++ b/src/Apps/cardapius.restaurant.app/src/shared/auth/AuthProvider.tsx
@@ -1,0 +1,116 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { UserManager, User } from 'oidc-client-ts';
+
+interface AuthContextValue {
+  user: User | null;
+  signin: () => Promise<void>;
+  signout: () => Promise<void>;
+  refresh: () => Promise<void>;
+  hasRole: (role: string) => boolean;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+  undefined,
+);
+
+const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const [userManager] = useState(
+    () =>
+      new UserManager({
+        client_id: process.env.REACT_APP_OIDC_CLIENT_ID || '',
+        authority: process.env.REACT_APP_OIDC_AUTHORITY || '',
+        redirect_uri: window.location.origin + '/callback',
+        silent_redirect_uri: window.location.origin + '/silent-renew',
+        scope: process.env.REACT_APP_OIDC_SCOPE || 'openid profile',
+        response_type: 'code',
+      }),
+  );
+
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    userManager.getUser().then(setUser);
+    userManager.events.addUserLoaded(setUser);
+    userManager.events.addUserUnloaded(() => setUser(null));
+    userManager.events.addAccessTokenExpiring(() => {
+      userManager.signinSilent();
+    });
+    userManager.events.addAccessTokenExpired(() => {
+      alert('Sessão expirada');
+      userManager.signinRedirect();
+    });
+
+    return () => {
+      userManager.events.removeUserLoaded(setUser);
+      userManager.events.removeUserUnloaded(() => setUser(null));
+    };
+  }, [userManager]);
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout;
+    const reset = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        alert('Sessão expirada por inatividade');
+        userManager.signoutRedirect();
+      }, INACTIVITY_TIMEOUT_MS);
+    };
+
+    document.addEventListener('mousemove', reset);
+    document.addEventListener('keydown', reset);
+    reset();
+
+    return () => {
+      document.removeEventListener('mousemove', reset);
+      document.removeEventListener('keydown', reset);
+      clearTimeout(timeout);
+    };
+  }, [userManager]);
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'logout') {
+        userManager.signoutRedirect();
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [userManager]);
+
+  const signin = () => userManager.signinRedirect();
+  const signout = () => {
+    localStorage.setItem('logout', Date.now().toString());
+    return userManager.signoutRedirect();
+  };
+  const refresh = () => userManager.signinSilent();
+  const hasRole = (role: string) => {
+    const roles = (user?.profile as any)?.roles as string[] | undefined;
+    return roles?.includes(role) ?? false;
+  };
+
+  const value = useMemo(
+    () => ({ user, signin, signout, refresh, hasRole }),
+    [user],
+  );
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};
+

--- a/src/Apps/cardapius.restaurant.app/src/shared/auth/index.ts
+++ b/src/Apps/cardapius.restaurant.app/src/shared/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './AuthProvider';
+export * from './useHasRole';
+

--- a/src/Apps/cardapius.restaurant.app/src/shared/auth/useHasRole.test.tsx
+++ b/src/Apps/cardapius.restaurant.app/src/shared/auth/useHasRole.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { AuthContext } from './AuthProvider';
+import { useHasRole } from './useHasRole';
+
+describe('useHasRole', () => {
+  it('returns true when role is present', () => {
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <AuthContext.Provider
+        value={{
+          user: { profile: { roles: ['admin'] } } as any,
+          signin: async () => {},
+          signout: async () => {},
+          refresh: async () => {},
+          hasRole: (r: string) => r === 'admin',
+        }}
+      >
+        {children}
+      </AuthContext.Provider>
+    );
+    const { result } = renderHook(() => useHasRole('admin'), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when role is absent', () => {
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <AuthContext.Provider
+        value={{
+          user: { profile: { roles: ['user'] } } as any,
+          signin: async () => {},
+          signout: async () => {},
+          refresh: async () => {},
+          hasRole: (r: string) => false,
+        }}
+      >
+        {children}
+      </AuthContext.Provider>
+    );
+    const { result } = renderHook(() => useHasRole('admin'), { wrapper });
+    expect(result.current).toBe(false);
+  });
+});
+

--- a/src/Apps/cardapius.restaurant.app/src/shared/auth/useHasRole.ts
+++ b/src/Apps/cardapius.restaurant.app/src/shared/auth/useHasRole.ts
@@ -1,0 +1,7 @@
+import { useAuth } from './AuthProvider';
+
+export const useHasRole = (role: string) => {
+  const { hasRole } = useAuth();
+  return hasRole(role);
+};
+


### PR DESCRIPTION
## Summary
- add OIDC-based AuthProvider with session/role management
- expose useHasRole hook
- integrate AuthProvider at app root and configure via env variables

## Testing
- `npm test -- --watch=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3aa2bd0f08320bc44d523a8691905