### PR TITLE
refactor auth flow components with tests

### DIFF
--- a/src/Apps/erp/shared/auth/AuthProvider.tsx
+++ b/src/Apps/erp/shared/auth/AuthProvider.tsx
@@ -75,10 +75,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
     };
   }, []);
 
-  const getUrlAtual = () =>
-    `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`;
+  const getUrlAtual = useCallback(
+    () => `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`,
+    [location],
+  );
 
-  const signin = async () => {
+  const signin = useCallback(async () => {
     try {
       setError(null);
       setIsLoading(true);
@@ -87,13 +89,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
       await userManager.signinRedirect({ state: { returnTo } });
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
-    }
-    finally {
+    } finally {
       setIsLoading(false);
     }
-  };
+  }, [buildAuthErrorDetails, getUrlAtual, userManager]);
 
-  const signinCallback = async () => {
+  const signinCallback = useCallback(async () => {
     try {
       setError(null);
       setIsLoading(true);
@@ -104,7 +105,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
       const returnTo: string = state?.returnTo || sessionStorage.getItem('returnTo') || '/';
 
       if (returnTo.indexOf('/login') === 0 || returnTo.indexOf('/callback') === 0 || returnTo.indexOf('/logout') === 0) {
-        await navigate("/", { replace: true });
+        await navigate('/', { replace: true });
         return;
       }
 
@@ -112,44 +113,44 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
       await navigate(returnTo, { replace: true });
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
-    }
-    finally {
+    } finally {
       setIsLoading(false);
     }
-  };
+  }, [buildAuthErrorDetails, navigate, userManager]);
 
-  const signout = async () => {
+  const signout = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
       setUser(null);
-      sessionStorage.setItem('returnTo', "/")
+      sessionStorage.setItem('returnTo', '/');
       await userManager.signoutRedirect({ state: { returnTo: '/' } });
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
-    }
-    finally {
+    } finally {
       setIsLoading(false);
     }
-  };
+  }, [buildAuthErrorDetails, userManager]);
 
-  const refresh = async () => {
+  const refresh = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
       await userManager.signinSilent();
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
-    }
-    finally {
+    } finally {
       setIsLoading(false);
     }
-  };
+  }, [buildAuthErrorDetails, userManager]);
 
-  const hasRole = (role: string) => {
-    const roles = (user?.profile as any)?.roles as string[] | undefined;
-    return roles?.includes(role) ?? false;
-  };
+  const hasRole = useCallback(
+    (role: string) => {
+      const roles = (user?.profile as any)?.roles as string[] | undefined;
+      return roles?.includes(role) ?? false;
+    },
+    [user],
+  );
 
   useEffect(() => {
     userManager.getUser().then((user) => {
@@ -208,7 +209,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
 
   const value = useMemo<AuthContextValue>(
     () => ({ user, isLoading, signin, signinCallback, signout, refresh, hasRole, error }),
-    [user, isLoading, error],
+    [user, isLoading, signin, signinCallback, signout, refresh, hasRole, error],
   );
 
   return (

--- a/src/Apps/erp/shared/auth/PrivateRoute.test.tsx
+++ b/src/Apps/erp/shared/auth/PrivateRoute.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PrivateRoute } from './PrivateRoute';
+import { useAuth } from './AuthProvider';
+
+jest.mock('./AuthProvider', () => ({ useAuth: jest.fn() }));
+jest.mock('./components/LoadProgressPage', () => ({
+  LoadProgressPage: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+jest.mock('./components/ProcessErrorDetails', () => ({
+  ProcessErrorDetails: ({ details }: any) => <div>error:{details.title}</div>,
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+
+describe('PrivateRoute', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls signin and shows loader when unauthenticated', () => {
+    const signin = jest.fn();
+    mockUseAuth.mockReturnValue({ user: null, signin, hasRole: () => false, isLoading: false, error: null });
+    render(<PrivateRoute />);
+    expect(signin).toHaveBeenCalled();
+    expect(screen.getByText('Aguardando autenticação...')).toBeInTheDocument();
+  });
+
+  it('renders children when authenticated', () => {
+    mockUseAuth.mockReturnValue({ user: {}, signin: jest.fn(), hasRole: () => true, isLoading: false, error: null });
+    render(
+      <PrivateRoute>
+        <div>secret</div>
+      </PrivateRoute>
+    );
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('denies access when missing role', () => {
+    mockUseAuth.mockReturnValue({
+      user: { profile: { roles: ['user'] } },
+      signin: jest.fn(),
+      hasRole: (r: string) => r === 'user',
+      isLoading: false,
+      error: null,
+    });
+    render(<PrivateRoute roles={['admin']} />);
+    expect(screen.getByText('Acesso negado')).toBeInTheDocument();
+  });
+
+  it('renders error component when error is present', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      signin: jest.fn(),
+      hasRole: () => false,
+      isLoading: false,
+      error: { title: 'err' },
+    });
+    render(<PrivateRoute />);
+    expect(screen.getByText('error:err')).toBeInTheDocument();
+  });
+});

--- a/src/Apps/erp/shared/auth/PrivateRoute.tsx
+++ b/src/Apps/erp/shared/auth/PrivateRoute.tsx
@@ -13,12 +13,10 @@ export const PrivateRoute: React.FC<PrivateRouteProps> = ({ roles, children }) =
   const { user, signin, hasRole, isLoading, error } = useAuth();
 
   useEffect(() => {
-    if (isLoading || user || error) {
-      return;
+    if (!isLoading && !user && !error) {
+      signin();
     }
-
-    signin();
-  }, []);
+  }, [error, isLoading, signin, user]);
 
   if (error) {
     return <ProcessErrorDetails details={error} onRetry={signin} />

--- a/src/Apps/erp/shared/auth/pages/Callback.test.tsx
+++ b/src/Apps/erp/shared/auth/pages/Callback.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Callback } from './Callback';
+import { useAuth } from '../AuthProvider';
+
+jest.mock('../AuthProvider', () => ({ useAuth: jest.fn() }));
+jest.mock('../components/LoadProgressPage', () => ({
+  LoadProgressPage: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+jest.mock('../components/ProcessErrorDetails', () => ({
+  ProcessErrorDetails: ({ details }: any) => <div>error:{details.title}</div>,
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+
+describe('Callback', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls signinCallback on mount when user not present', () => {
+    const signinCallback = jest.fn();
+    mockUseAuth.mockReturnValue({ signinCallback, signin: jest.fn(), error: null, isLoading: false, user: null });
+    render(<Callback />);
+    expect(signinCallback).toHaveBeenCalled();
+    expect(screen.getByText('Carregando informações...')).toBeInTheDocument();
+  });
+
+  it('renders error when error is present', () => {
+    mockUseAuth.mockReturnValue({ signinCallback: jest.fn(), signin: jest.fn(), error: { title: 'err' }, isLoading: false, user: null });
+    render(<Callback />);
+    expect(screen.getByText('error:err')).toBeInTheDocument();
+  });
+
+  it('does not call signinCallback when user is already authenticated', () => {
+    const signinCallback = jest.fn();
+    mockUseAuth.mockReturnValue({ signinCallback, signin: jest.fn(), error: null, isLoading: false, user: {} });
+    render(<Callback />);
+    expect(signinCallback).not.toHaveBeenCalled();
+  });
+});

--- a/src/Apps/erp/shared/auth/pages/Callback.tsx
+++ b/src/Apps/erp/shared/auth/pages/Callback.tsx
@@ -7,11 +7,10 @@ export const Callback = () => {
     const { signinCallback, signin, error, isLoading, user } = useAuth();
 
     useEffect(() => {
-        if (isLoading || user) {
-            return;
+        if (!isLoading && !user) {
+            signinCallback();
         }
-        signinCallback();
-    }, []);
+    }, [isLoading, signinCallback, user]);
 
     if (error) {
         return <ProcessErrorDetails details={error} onRetry={signin} />;

--- a/src/Apps/erp/shared/auth/useHasRole.test.tsx
+++ b/src/Apps/erp/shared/auth/useHasRole.test.tsx
@@ -1,43 +1,24 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react';
-import { AuthContext } from './AuthProvider';
 import { useHasRole } from './useHasRole';
+import { useAuth } from './AuthProvider';
+
+jest.mock('./AuthProvider', () => ({ useAuth: jest.fn() }));
+const mockUseAuth = useAuth as jest.Mock;
 
 describe('useHasRole', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns true when role is present', () => {
-    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <AuthContext.Provider
-        value={{
-          user: { profile: { roles: ['admin'] } } as any,
-          signin: async () => {},
-          signout: async () => {},
-          refresh: async () => {},
-          hasRole: (r: string) => r === 'admin',
-        }}
-      >
-        {children}
-      </AuthContext.Provider>
-    );
-    const { result } = renderHook(() => useHasRole('admin'), { wrapper });
+    mockUseAuth.mockReturnValue({ hasRole: (r: string) => r === 'admin' });
+    const { result } = renderHook(() => useHasRole('admin'));
     expect(result.current).toBe(true);
   });
 
   it('returns false when role is absent', () => {
-    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <AuthContext.Provider
-        value={{
-          user: { profile: { roles: ['user'] } } as any,
-          signin: async () => {},
-          signout: async () => {},
-          refresh: async () => {},
-          hasRole: () => false,
-        }}
-      >
-        {children}
-      </AuthContext.Provider>
-    );
-    const { result } = renderHook(() => useHasRole('admin'), { wrapper });
+    mockUseAuth.mockReturnValue({ hasRole: () => false });
+    const { result } = renderHook(() => useHasRole('admin'));
     expect(result.current).toBe(false);
   });
 });
-


### PR DESCRIPTION
## Summary
- refactor AuthProvider to memoize auth actions and context value
- simplify auth guard and callback pages and add unit tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b62ddb802c83209b93c8d949f2cf8b