### PR TITLE
Refactor auth context and add Sentinel telemetry

### DIFF
--- a/src/Apps/erp/shared/auth/AuthProvider.tsx
+++ b/src/Apps/erp/shared/auth/AuthProvider.tsx
@@ -7,54 +7,33 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { UserManager, User, WebStorageStateStore } from 'oidc-client-ts';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { OidcService } from './services/oidcService';
 import { AuthErrorDetails } from './types/AuthErrorDetails';
 import { AuthContextValue } from './types/AuthContextValue';
+import { AuthClient, createAuthClient } from './services/authClient';
+import { AuthUser } from './types/AuthUser';
 
 export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
 
-export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+interface AuthProviderProps {
+  client?: AuthClient;
+}
+
+export const AuthProvider: React.FC<React.PropsWithChildren<AuthProviderProps>> = ({
+  children,
+  client,
+}) => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // --- UserManager (silent renew automático + sessionStorage) ---
-  const userManager = useMemo(
-    () =>
-      new UserManager({
-        client_id: import.meta.env.VITE_OIDC_CLIENT_ID || '',
-        authority: import.meta.env.VITE_OIDC_AUTHORITY || '',
-        redirect_uri: `${window.location.origin}/callback`,
-        silent_redirect_uri: `${window.location.origin}/silent-renew`,
-        post_logout_redirect_uri: `${window.location.origin}/login`,
-
-        scope: import.meta.env.VITE_OIDC_SCOPE || 'openid profile',
-        response_type: 'code',
-
-        // segurança/desempenho
-        loadUserInfo: false,
-        filterProtocolClaims: true,
-        revokeTokensOnSignout: true,
-
-        // silent renew nativo da lib
-        automaticSilentRenew: true,
-        accessTokenExpiringNotificationTimeInSeconds: 60, // tente renovar 60s antes do expirar
-        silentRequestTimeoutInSeconds: 20,
-
-        // menos persistente que localStorage
-        userStore: new WebStorageStateStore({
-          store: window.sessionStorage,
-          prefix: 'oidc',
-        }),
-      }),
-    []
-  );
+  // --- Auth client wrapper (silent renew automático + sessionStorage) ---
+  const authClient = useMemo(() => client ?? createAuthClient(), [client]);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
   const [error, setError] = useState<AuthErrorDetails | null>(null);
 
   // trava simples para evitar concorrência no refresh manual
@@ -86,12 +65,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         traceId,
         requestId,
         timestamp: new Date().toISOString(),
-        authority: userManager.settings.authority,
-        clientId: userManager.settings.client_id ?? null,
-        redirectUri: userManager.settings.redirect_uri ?? null,
+        authority: authClient.settings.authority,
+        clientId: authClient.settings.client_id ?? null,
+        redirectUri: authClient.settings.redirect_uri ?? null,
       };
     },
-    [userManager]
+    [authClient]
   );
 
   const getUrlAtual = useCallback(
@@ -105,19 +84,19 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setIsLoading(true);
       const returnTo = getUrlAtual();
       sessionStorage.setItem('returnTo', returnTo); // fallback pós-login
-      await userManager.signinRedirect({ state: { returnTo } });
+      await authClient.signinRedirect({ state: { returnTo } });
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
     } finally {
       setIsLoading(false);
     }
-  }, [buildAuthErrorDetails, getUrlAtual, userManager]);
+  }, [buildAuthErrorDetails, getUrlAtual, authClient]);
 
   const signinCallback = useCallback(async () => {
     try {
       setError(null);
       setIsLoading(true);
-      const loggedUser = await userManager.signinRedirectCallback();
+      const loggedUser = await authClient.signinRedirectCallback();
       setUser(loggedUser);
 
       const state = (loggedUser?.state as any) || {};
@@ -141,7 +120,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     } finally {
       setIsLoading(false);
     }
-  }, [buildAuthErrorDetails, navigate, userManager]);
+  }, [buildAuthErrorDetails, navigate, authClient]);
 
   const signout = useCallback(async () => {
     try {
@@ -149,13 +128,13 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setError(null);
       setUser(null);
       sessionStorage.setItem('returnTo', '/');
-      await userManager.signoutRedirect({ state: { returnTo: '/' } });
+      await authClient.signoutRedirect({ state: { returnTo: '/' } });
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
     } finally {
       setIsLoading(false);
     }
-  }, [buildAuthErrorDetails, userManager]);
+  }, [buildAuthErrorDetails, authClient]);
 
   // refresh manual (mantido para fallback/log), com trava
   const refresh = useCallback(async () => {
@@ -163,14 +142,14 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     isRefreshingRef.current = true;
     try {
       setError(null);
-      await userManager.signinSilent();
+      await authClient.signinSilent();
     } catch (err: any) {
       setError(await buildAuthErrorDetails(err));
     } finally {
       isRefreshingRef.current = false;
       setIsLoading(false);
     }
-  }, [buildAuthErrorDetails, userManager]);
+  }, [buildAuthErrorDetails, authClient]);
 
   const hasRole = useCallback(
     (role: string) => {
@@ -180,11 +159,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     [user]
   );
 
-  // --- Eventos do UserManager (com mesmas referências e cleanup correto) ---
+  // --- Eventos do cliente de autenticação (com mesmas referências e cleanup correto) ---
   useEffect(() => {
     let mounted = true;
 
-    const onUserLoaded = (u: User) => {
+    const onUserLoaded = (u: AuthUser) => {
       if (!mounted) return;
       setUser(u);
       setIsLoading(false);
@@ -205,25 +184,25 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       // refresh();
     };
 
-    userManager.getUser().then((u) => {
+    authClient.getUser().then((u) => {
       if (!mounted) return;
       setUser(u);
       setIsLoading(false);
     });
 
-    userManager.events.addUserLoaded(onUserLoaded);
-    userManager.events.addUserUnloaded(onUserUnloaded);
-    userManager.events.addSilentRenewError(onSilentRenewError);
-    userManager.events.addAccessTokenExpiring(onAccessTokenExpiring);
+    authClient.events.addUserLoaded(onUserLoaded);
+    authClient.events.addUserUnloaded(onUserUnloaded);
+    authClient.events.addSilentRenewError(onSilentRenewError);
+    authClient.events.addAccessTokenExpiring(onAccessTokenExpiring);
 
     return () => {
       mounted = false;
-      userManager.events.removeUserLoaded(onUserLoaded);
-      userManager.events.removeUserUnloaded(onUserUnloaded);
-      userManager.events.removeSilentRenewError(onSilentRenewError);
-      userManager.events.removeAccessTokenExpiring(onAccessTokenExpiring);
+      authClient.events.removeUserLoaded(onUserLoaded);
+      authClient.events.removeUserUnloaded(onUserUnloaded);
+      authClient.events.removeSilentRenewError(onSilentRenewError);
+      authClient.events.removeAccessTokenExpiring(onAccessTokenExpiring);
     };
-  }, [userManager, refresh]);
+  }, [authClient, refresh]);
 
   // --- Inatividade: desloga após X ms sem interação ---
   useEffect(() => {
@@ -233,7 +212,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       clearTimeout(timeout);
       timeout = setTimeout(() => {
         alert('Sessão expirada por inatividade');
-        userManager.signoutRedirect();
+        authClient.signoutRedirect();
       }, INACTIVITY_TIMEOUT_MS);
     };
 
@@ -246,21 +225,31 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       document.removeEventListener('keydown', reset);
       clearTimeout(timeout);
     };
-  }, [userManager]);
+  }, [authClient]);
 
   // --- Single logout multi-abas (storage event) ---
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === 'logout') {
-        userManager.signoutRedirect();
+        authClient.signoutRedirect();
       }
     };
     window.addEventListener('storage', handler);
     return () => window.removeEventListener('storage', handler);
-  }, [userManager]);
+  }, [authClient]);
 
   const value = useMemo<AuthContextValue>(
-    () => ({ user, isLoading, signin, signinCallback, signout, refresh, hasRole, error }),
+    () => ({
+      user,
+      isLoading,
+      isAuthenticated: !!user,
+      signin,
+      signinCallback,
+      signout,
+      refresh,
+      hasRole,
+      error,
+    }),
     [user, isLoading, signin, signinCallback, signout, refresh, hasRole, error]
   );
 

--- a/src/Apps/erp/shared/auth/PrivateRoute.test.tsx
+++ b/src/Apps/erp/shared/auth/PrivateRoute.test.tsx
@@ -20,14 +20,28 @@ describe('PrivateRoute', () => {
 
   it('calls signin and shows loader when unauthenticated', () => {
     const signin = jest.fn();
-    mockUseAuth.mockReturnValue({ user: null, signin, hasRole: () => false, isLoading: false, error: null });
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      signin,
+      hasRole: () => false,
+      isLoading: false,
+      error: null,
+    });
     render(<PrivateRoute />);
     expect(signin).toHaveBeenCalled();
     expect(screen.getByText('Aguardando autenticação...')).toBeInTheDocument();
   });
 
   it('renders children when authenticated', () => {
-    mockUseAuth.mockReturnValue({ user: {}, signin: jest.fn(), hasRole: () => true, isLoading: false, error: null });
+    mockUseAuth.mockReturnValue({
+      user: {},
+      isAuthenticated: true,
+      signin: jest.fn(),
+      hasRole: () => true,
+      isLoading: false,
+      error: null,
+    });
     render(
       <PrivateRoute>
         <div>secret</div>
@@ -39,6 +53,7 @@ describe('PrivateRoute', () => {
   it('denies access when missing role', () => {
     mockUseAuth.mockReturnValue({
       user: { profile: { roles: ['user'] } },
+      isAuthenticated: true,
       signin: jest.fn(),
       hasRole: (r: string) => r === 'user',
       isLoading: false,
@@ -51,6 +66,7 @@ describe('PrivateRoute', () => {
   it('renders error component when error is present', () => {
     mockUseAuth.mockReturnValue({
       user: null,
+      isAuthenticated: false,
       signin: jest.fn(),
       hasRole: () => false,
       isLoading: false,

--- a/src/Apps/erp/shared/auth/PrivateRoute.tsx
+++ b/src/Apps/erp/shared/auth/PrivateRoute.tsx
@@ -10,15 +10,13 @@ interface PrivateRouteProps {
 }
 
 export const PrivateRoute: React.FC<PrivateRouteProps> = ({ roles, children }) => {
-  const { user, signin, hasRole, isLoading, error, isAuthenticated } = useAuth();
-
-  console.log('PrivateRoute', { user, isLoading, error });
+  const { signin, hasRole, isLoading, error, isAuthenticated } = useAuth();
 
   useEffect(() => {
-    if (!isLoading && !user && !error) {
+    if (!isLoading && !isAuthenticated && !error) {
       signin();
     }
-  }, [error, isLoading, signin, user]);
+  }, [error, isLoading, isAuthenticated, signin]);
 
   if (error) {
     return <ProcessErrorDetails details={error} onRetry={signin} />

--- a/src/Apps/erp/shared/auth/services/authClient.ts
+++ b/src/Apps/erp/shared/auth/services/authClient.ts
@@ -1,0 +1,66 @@
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
+import { AuthUser } from '../types/AuthUser';
+
+export interface AuthClient {
+  getUser(): Promise<AuthUser | null>;
+  signinRedirect(args?: Record<string, unknown>): Promise<void>;
+  signinRedirectCallback(): Promise<AuthUser>;
+  signoutRedirect(args?: Record<string, unknown>): Promise<void>;
+  signinSilent(): Promise<AuthUser>;
+  events: {
+    addUserLoaded(cb: (user: AuthUser) => void): void;
+    addUserUnloaded(cb: () => void): void;
+    addSilentRenewError(cb: (error: unknown) => void): void;
+    addAccessTokenExpiring(cb: () => void): void;
+    removeUserLoaded(cb: (user: AuthUser) => void): void;
+    removeUserUnloaded(cb: () => void): void;
+    removeSilentRenewError(cb: (error: unknown) => void): void;
+    removeAccessTokenExpiring(cb: () => void): void;
+  };
+  settings: {
+    authority?: string;
+    client_id?: string;
+    redirect_uri?: string;
+  };
+}
+
+export const createAuthClient = (): AuthClient => {
+  const manager = new UserManager({
+    client_id: import.meta.env.VITE_OIDC_CLIENT_ID || '',
+    authority: import.meta.env.VITE_OIDC_AUTHORITY || '',
+    redirect_uri: `${window.location.origin}/callback`,
+    silent_redirect_uri: `${window.location.origin}/silent-renew`,
+    post_logout_redirect_uri: `${window.location.origin}/login`,
+    scope: import.meta.env.VITE_OIDC_SCOPE || 'openid profile',
+    response_type: 'code',
+    loadUserInfo: false,
+    filterProtocolClaims: true,
+    revokeTokensOnSignout: true,
+    automaticSilentRenew: true,
+    accessTokenExpiringNotificationTimeInSeconds: 60,
+    silentRequestTimeoutInSeconds: 20,
+    userStore: new WebStorageStateStore({
+      store: window.sessionStorage,
+      prefix: 'oidc',
+    }),
+  });
+
+  return {
+    getUser: () => manager.getUser() as Promise<AuthUser | null>,
+    signinRedirect: (args) => manager.signinRedirect(args),
+    signinRedirectCallback: () => manager.signinRedirectCallback() as Promise<AuthUser>,
+    signoutRedirect: (args) => manager.signoutRedirect(args),
+    signinSilent: () => manager.signinSilent() as Promise<AuthUser>,
+    events: {
+      addUserLoaded: (cb) => manager.events.addUserLoaded(cb as any),
+      addUserUnloaded: (cb) => manager.events.addUserUnloaded(cb),
+      addSilentRenewError: (cb) => manager.events.addSilentRenewError(cb),
+      addAccessTokenExpiring: (cb) => manager.events.addAccessTokenExpiring(cb),
+      removeUserLoaded: (cb) => manager.events.removeUserLoaded(cb as any),
+      removeUserUnloaded: (cb) => manager.events.removeUserUnloaded(cb),
+      removeSilentRenewError: (cb) => manager.events.removeSilentRenewError(cb),
+      removeAccessTokenExpiring: (cb) => manager.events.removeAccessTokenExpiring(cb),
+    },
+    settings: manager.settings,
+  };
+};

--- a/src/Apps/erp/shared/auth/types/AuthContextValue.ts
+++ b/src/Apps/erp/shared/auth/types/AuthContextValue.ts
@@ -1,8 +1,8 @@
-import { User } from "oidc-client-ts";
 import { AuthErrorDetails } from "./AuthErrorDetails";
+import { AuthUser } from "./AuthUser";
 
 export interface AuthContextValue {
-  user: User | null;
+  user: AuthUser | null;
   isLoading: boolean;
   isAuthenticated: boolean;
   signin: () => Promise<void>;

--- a/src/Apps/erp/shared/auth/types/AuthUser.ts
+++ b/src/Apps/erp/shared/auth/types/AuthUser.ts
@@ -1,0 +1,4 @@
+export interface AuthUser {
+  profile?: Record<string, unknown>;
+  [key: string]: unknown;
+}

--- a/src/Core/Services/Sentinel/Sentinel.Api/Extensions/SentinelBuilderExtensions.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Extensions/SentinelBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using BuildingBlock.Observability.OpenTelemetry.Extensions;
+using FluentValidation.AspNetCore;
+
+namespace Sentinel.Api.Extensions;
+
+public static class SentinelBuilderExtensions
+{
+    public static WebApplicationBuilder AddSentinel(this WebApplicationBuilder builder)
+    {
+        builder.AddObservability();
+        builder.Host.AddAppLogging(builder.Configuration);
+        builder.Services.AddControllersWithViews();
+        builder.Services.AddRazorPages();
+
+        builder.Services.AddDatabase(builder.Configuration);
+        builder.Services.AddIdentity();
+        builder.Services.AddAppAuthentication(builder.Configuration);
+
+        builder.Services.AddServices();
+        builder.Services.AddAppRateLimiter(builder.Configuration);
+
+        builder.Services.AddCors();
+        builder.Services.AddControllers();
+        builder.Services.AddFluentValidationAutoValidation();
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddAppSwagger();
+        builder.Services.AddHealthChecks();
+
+        return builder;
+    }
+}

--- a/src/Core/Services/Sentinel/Sentinel.Api/Extensions/WebApplicationExtensions.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Extensions/WebApplicationExtensions.cs
@@ -1,9 +1,26 @@
+using Sentinel.Api.Middleware;
+
 namespace Sentinel.Api.Extensions;
 
 public static class WebApplicationExtensions
 {
     public static WebApplication UseSentinel(this WebApplication app)
     {
+        app.UseAppLogging();
+        app.UseCors(policy => policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
+        app.UseFrameAncestors();
+        app.UseExceptionHandling();
+        app.UseStatusCodePagesWithReExecute("/error/{0}");
+        app.UseCorrelationId();
+        app.UseRouting();
+        app.UseAppRateLimiter();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseStaticFiles();
+
+        app.UseAppSwagger();
+        app.MapControllers();
+        app.MapHealthChecks("/health");
 
         return app;
     }

--- a/src/Core/Services/Sentinel/Sentinel.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using System.Net;
+
+namespace Sentinel.Api.Middleware;
+
+public class ExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+    public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            var traceId = Activity.Current?.Id ?? context.TraceIdentifier;
+            _logger.LogError(ex, "Unhandled exception with trace id {TraceId}", traceId);
+
+            var acceptsHtml = context.Request.Headers.TryGetValue("Accept", out var accept) &&
+                               accept.Any(a => a.Contains("text/html", StringComparison.OrdinalIgnoreCase));
+
+            if (acceptsHtml)
+            {
+                context.Response.Redirect("/error");
+            }
+            else
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsJsonAsync(new
+                {
+                    message = "Ocorreu um erro inesperado. Tente novamente mais tarde.",
+                    traceId
+                });
+            }
+        }
+    }
+}
+
+public static class ExceptionHandlingExtensions
+{
+    public static IApplicationBuilder UseExceptionHandling(this IApplicationBuilder app)
+        => app.UseMiddleware<ExceptionHandlingMiddleware>();
+}
+

--- a/src/Core/Services/Sentinel/Sentinel.Api/Program.cs
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Program.cs
@@ -1,43 +1,9 @@
-using FluentValidation.AspNetCore;
 using Sentinel.Api.Extensions;
-using Sentinel.Api.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Host.AddAppLogging(builder.Configuration);
-builder.Services.AddControllersWithViews();
-builder.Services.AddRazorPages();
-
-builder.Services.AddDatabase(builder.Configuration);
-builder.Services.AddIdentity();
-builder.Services.AddAppAuthentication(builder.Configuration);
-
-builder.Services.AddServices();
-builder.Services.AddAppRateLimiter(builder.Configuration);
-
-builder.Services.AddCors();
-builder.Services.AddControllers();
-builder.Services.AddFluentValidationAutoValidation();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddAppSwagger();
-builder.Services.AddHealthChecks();
+builder.AddSentinel();
 
 var app = builder.Build();
-
-app.UseAppLogging();
-app.UseCors(policy => policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
-app.UseFrameAncestors();
-app.UseExceptionHandler("/error");
-app.UseStatusCodePagesWithReExecute("/error/{0}");
-app.UseCorrelationId();
-app.UseRouting();
-app.UseAppRateLimiter();
-app.UseAuthentication();
-app.UseAuthorization();
-app.UseStaticFiles();
-
-app.UseAppSwagger();
-app.MapControllers();
-app.MapHealthChecks("/health");
+app.UseSentinel();
 
 await app.RunAsync();

--- a/src/Core/Services/Sentinel/Sentinel.Api/Sentinel.Api.csproj
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Sentinel.Api.csproj
@@ -14,9 +14,9 @@
 		<None Remove="Pages\**" />
 		<None Remove="Resources\**" />
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+        <ItemGroup>
+                <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+                <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
 			<PrivateAssets>all</PrivateAssets>
@@ -27,10 +27,13 @@
 		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.0.0" />
 		<PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.0.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-	</ItemGroup>
-	<ItemGroup>
-		<Folder Include="Migrations\" />
-	</ItemGroup>
+                <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+                <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        </ItemGroup>
+        <ItemGroup>
+                <ProjectReference Include="..\..\..\BuildingBlocks\Driven\BuildingBlock.Observability.OpenTelemetry\BuildingBlock.Observability.OpenTelemetry.csproj" />
+        </ItemGroup>
+        <ItemGroup>
+                <Folder Include="Migrations\" />
+        </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- introduce `AuthClient` wrapper and `AuthUser` type to decouple auth provider from oidc library
- expose high-level builder and app extensions to configure Sentinel services and pipeline
- add global exception middleware to log and return sanitized errors in Sentinel API

## Testing
- ❌ `dotnet build src/Core/Services/Sentinel/Sentinel.Api/Sentinel.Api.csproj` (command not found: dotnet)
- ❌ `npm test` (jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c61a3edfe083208c542d4ba801e205