### PR TITLE
Handle clipboard fallback in ProcessErrorDetails copy action

### DIFF
--- a/src/Apps/erp/shared/auth/components/ProcessErrorDetails.tsx
+++ b/src/Apps/erp/shared/auth/components/ProcessErrorDetails.tsx
@@ -19,11 +19,33 @@ export const ProcessErrorDetails: React.FC<ProcessErrorDetailsProps> = ({
     const navigate = useNavigate();
     const [open, setOpen] = useState<boolean>(false);
 
-    const copyDetails = async () => {
+    const copyDetails = useCallback(async () => {
+        const serializedDetails = JSON.stringify(details, null, 2);
+
         try {
-            await navigator.clipboard.writeText(JSON.stringify(details, null, 2));
-        } catch { }
-    };
+            if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(serializedDetails);
+                return;
+            }
+        } catch {
+            // ignored so we can fallback to the legacy API below
+        }
+
+        if (typeof document === 'undefined' || !document.execCommand) {
+            return;
+        }
+
+        const textArea = document.createElement('textarea');
+        textArea.value = serializedDetails;
+        textArea.setAttribute('readonly', '');
+        textArea.style.position = 'absolute';
+        textArea.style.left = '-9999px';
+
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+    }, [details]);
 
     const contactSupport = () => {
 
@@ -31,7 +53,7 @@ export const ProcessErrorDetails: React.FC<ProcessErrorDetailsProps> = ({
 
     const handleHome = useCallback(() => {
         navigate("/");
-    }, [])
+    }, [navigate])
 
     return (
         <Box


### PR DESCRIPTION
## Summary
- guard the ProcessErrorDetails copy action with navigator.clipboard checks and a legacy textarea fallback
- memoize the copy handler and fix the missing dependency for the home navigation callback

## Testing
- Not run (npm install failed: 403 Forbidden when downloading packages)

------
https://chatgpt.com/codex/tasks/task_e_68d9db394f4c83209a14416f8a57c761