### PR TITLE
Update NuGet package versions across projects

### DIFF
--- a/src/Core/BuildingBlocks/Core/BuildingBlock.Application/BuildingBlock.Application.csproj
+++ b/src/Core/BuildingBlocks/Core/BuildingBlock.Application/BuildingBlock.Application.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
 		<PackageReference Include="MediatR" Version="[12.5.0]" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Core/BuildingBlocks/Core/test/BuildingBlock.Application.UnitTest/BuildingBlock.Application.UnitTest.csproj
+++ b/src/Core/BuildingBlocks/Core/test/BuildingBlock.Application.UnitTest/BuildingBlock.Application.UnitTest.csproj
@@ -13,11 +13,11 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.6.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="FluentAssertions" Version="8.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/Core/BuildingBlocks/Core/test/BuildingBlock.Domain.UnitTest/BuildingBlock.Domain.UnitTest.csproj
+++ b/src/Core/BuildingBlocks/Core/test/BuildingBlock.Domain.UnitTest/BuildingBlock.Domain.UnitTest.csproj
@@ -11,10 +11,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.6.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="FluentAssertions" Version="8.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/Core/BuildingBlocks/Driven/BuildingBlock.Domain.ValueObject.EFCore/BuildingBlock.Infra.Domain.ValueObjects.EFCore.csproj
+++ b/src/Core/BuildingBlocks/Driven/BuildingBlock.Domain.ValueObject.EFCore/BuildingBlock.Infra.Domain.ValueObjects.EFCore.csproj
@@ -6,7 +6,7 @@
 		<SonarQubeExclude>true</SonarQubeExclude>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Core\BuildingBlock.Domain\BuildingBlock.Domain.csproj" />

--- a/src/Core/BuildingBlocks/Driven/BuildingBlock.Infra.DataBase.EntityFramework/BuildingBlock.Infra.DataBase.EntityFramework.csproj
+++ b/src/Core/BuildingBlocks/Driven/BuildingBlock.Infra.DataBase.EntityFramework/BuildingBlock.Infra.DataBase.EntityFramework.csproj
@@ -14,14 +14,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.10">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Core/BuildingBlocks/Driven/BuildingBlock.Infra.DataBase.MongoDB/BuildingBlock.Infra.DataBase.MongoDB.csproj
+++ b/src/Core/BuildingBlocks/Driven/BuildingBlock.Infra.DataBase.MongoDB/BuildingBlock.Infra.DataBase.MongoDB.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
 		<PackageReference Include="MongoDB.Driver" Version="3.5.0" />
 	</ItemGroup>
   <ItemGroup>

--- a/src/Core/BuildingBlocks/Driven/BuildingBlock.Observability.OpenTelemetry/BuildingBlock.Observability.OpenTelemetry.csproj
+++ b/src/Core/BuildingBlocks/Driven/BuildingBlock.Observability.OpenTelemetry/BuildingBlock.Observability.OpenTelemetry.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.13.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.0.0-rc9.13" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.13" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.13" />

--- a/src/Core/BuildingBlocks/Driving/BuildingBlock.Api.Domain.ValueObjects.Json/BuildingBlock.Api.Domain.ValueObjects.Json.csproj
+++ b/src/Core/BuildingBlocks/Driving/BuildingBlock.Api.Domain.ValueObjects.Json/BuildingBlock.Api.Domain.ValueObjects.Json.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.10" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Core/BuildingBlocks/Driving/BuildingBlock.Api/BuildingBlock.Api.csproj
+++ b/src/Core/BuildingBlocks/Driving/BuildingBlock.Api/BuildingBlock.Api.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.2" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Core/BuildingBlocks/Driving/BuildingBlock.Swashbuckle.Domain.ValueObjects.Map/BuildingBlock.Api.Swashbuckle.Domain.ValueObjects.Map.csproj
+++ b/src/Core/BuildingBlocks/Driving/BuildingBlock.Swashbuckle.Domain.ValueObjects.Map/BuildingBlock.Api.Swashbuckle.Domain.ValueObjects.Map.csproj
@@ -6,7 +6,7 @@
 		<SonarQubeExclude>true</SonarQubeExclude>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Core\BuildingBlock.Domain\BuildingBlock.Domain.csproj" />

--- a/src/Core/BuildingBlocks/Driving/BuildingBlock.Swashbuckle/BuildingBlock.Api.Swashbuckle.csproj
+++ b/src/Core/BuildingBlocks/Driving/BuildingBlock.Swashbuckle/BuildingBlock.Api.Swashbuckle.csproj
@@ -10,6 +10,6 @@
 		<ProjectReference Include="..\BuildingBlock.Swashbuckle.Domain.ValueObjects.Map\BuildingBlock.Api.Swashbuckle.Domain.ValueObjects.Map.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
 	</ItemGroup>
 </Project>

--- a/src/Core/Cardapius.AppHost/Cardapius.AppHost.csproj
+++ b/src/Core/Cardapius.AppHost/Cardapius.AppHost.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.2" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Services/Administration/Adapters/Driven/Administration.Infra.DataBase.EntityFramework/Administration.Infra.DataBase.EntityFramework.csproj
+++ b/src/Core/Services/Administration/Adapters/Driven/Administration.Infra.DataBase.EntityFramework/Administration.Infra.DataBase.EntityFramework.csproj
@@ -6,12 +6,12 @@
 		<SonarQubeExclude>true</SonarQubeExclude>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\..\..\BuildingBlocks\Driven\BuildingBlock.Domain.ValueObject.EFCore\BuildingBlock.Infra.Domain.ValueObjects.EFCore.csproj" />

--- a/src/Core/Services/Administration/Adapters/Driving/Administration.Api/Administration.Api.csproj
+++ b/src/Core/Services/Administration/Adapters/Driving/Administration.Api/Administration.Api.csproj
@@ -21,9 +21,9 @@
 		<Folder Include="Extensions\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9" NoWarn="NU1608">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.10" NoWarn="NU1608">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<NoWarn>NU1608</NoWarn>

--- a/src/Core/Services/Administration/tests/Administration.Application.UnitTest/Administration.Application.UnitTest.csproj
+++ b/src/Core/Services/Administration/tests/Administration.Application.UnitTest/Administration.Application.UnitTest.csproj
@@ -15,11 +15,11 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.6.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="FluentAssertions" Version="8.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Core/Services/Administration/tests/Administration.Domain.UnitTest/Administration.Domain.UnitTest.csproj
+++ b/src/Core/Services/Administration/tests/Administration.Domain.UnitTest/Administration.Domain.UnitTest.csproj
@@ -13,10 +13,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.6.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="FluentAssertions" Version="8.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Core/Services/Sentinel/Sentinel.Api/Sentinel.Api.csproj
+++ b/src/Core/Services/Sentinel/Sentinel.Api/Sentinel.Api.csproj
@@ -17,8 +17,8 @@
         <ItemGroup>
                 <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
                 <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -28,7 +28,7 @@
 		<PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.1.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
                 <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-                <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+                <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
         </ItemGroup>
         <ItemGroup>
                 <ProjectReference Include="..\..\..\BuildingBlocks\Driven\BuildingBlock.Observability.OpenTelemetry\BuildingBlock.Observability.OpenTelemetry.csproj" />

--- a/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
+++ b/src/Core/Services/Sentinel/tests/Sentinel.Api.UnitTests/Sentinel.Api.UnitTests.csproj
@@ -10,11 +10,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.6.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Core/Services/Store/Adapters/Driving/Store.Api/Directory.Packages.props
+++ b/src/Core/Services/Store/Adapters/Driving/Store.Api/Directory.Packages.props
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgraded various NuGet dependencies to their latest versions, including Microsoft.AspNetCore, EntityFrameworkCore, Swashbuckle.AspNetCore, OpenTelemetry, FluentAssertions, and test SDKs. This ensures compatibility, security, and access to new features and bug fixes.