### PR TITLE
Add tests for auth login and logout pages

### DIFF
--- a/src/Apps/erp/shared/auth/pages/Login.test.tsx
+++ b/src/Apps/erp/shared/auth/pages/Login.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Login } from './Login';
+import { useAuth } from '../AuthProvider';
+
+jest.mock('../AuthProvider', () => ({ useAuth: jest.fn() }));
+jest.mock('../components/LoadProgressPage', () => ({
+  LoadProgressPage: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+jest.mock('../components/ProcessErrorDetails', () => ({
+  ProcessErrorDetails: ({ details }: any) => <div>error:{details.title}</div>,
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+
+describe('Login page', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls signin on mount and shows loading state', async () => {
+    const signin = jest.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ signin });
+
+    render(<Login />);
+
+    await waitFor(() => expect(signin).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Processando informações de login...')).toBeInTheDocument();
+  });
+
+  it('renders error details when signin returns an error', async () => {
+    const signin = jest.fn().mockResolvedValue({ title: 'signin-error' });
+    mockUseAuth.mockReturnValue({ signin });
+
+    render(<Login />);
+
+    expect(await screen.findByText('error:signin-error')).toBeInTheDocument();
+    expect(signin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Apps/erp/shared/auth/pages/Logout.test.tsx
+++ b/src/Apps/erp/shared/auth/pages/Logout.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Logout } from './Logout';
+import { useAuth } from '../AuthProvider';
+
+jest.mock('../AuthProvider', () => ({ useAuth: jest.fn() }));
+jest.mock('../components/LoadProgressPage', () => ({
+  LoadProgressPage: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+jest.mock('../components/ProcessErrorDetails', () => ({
+  ProcessErrorDetails: ({ details }: any) => <div>error:{details.title}</div>,
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+
+describe('Logout page', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls signout on mount and shows loading state', async () => {
+    const signout = jest.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ signout });
+
+    render(<Logout />);
+
+    await waitFor(() => expect(signout).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Processando logout...')).toBeInTheDocument();
+  });
+
+  it('renders error details when signout returns an error', async () => {
+    const signout = jest.fn().mockResolvedValue({ title: 'signout-error' });
+    mockUseAuth.mockReturnValue({ signout });
+
+    render(<Logout />);
+
+    expect(await screen.findByText('error:signout-error')).toBeInTheDocument();
+    expect(signout).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering Login page sign-in flow and error handling
- add unit tests covering Logout page sign-out flow and error handling

## Testing
- npm test -- --runInBand *(fails: jest not found due to missing install permissions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928506a9e8c8320b8b93a6dd440b104)