### PR TITLE
Refine sidemenu filtering and tests

### DIFF
--- a/src/Apps/erp/menuItems.test.tsx
+++ b/src/Apps/erp/menuItems.test.tsx
@@ -1,0 +1,43 @@
+import { buildSearchTerms, filterMenuItems, menuItems } from './menuItems';
+
+describe('menuItems filtering', () => {
+    const allowAllRoles = () => true;
+
+    it('returns all accessible items when there is no search term', () => {
+        const items = filterMenuItems(menuItems, '', allowAllRoles);
+
+        expect(items).toHaveLength(menuItems.length);
+    });
+
+    it('hides items behind roles that the user does not have', () => {
+        const denyPdvRole = (role: string) => role !== 'pdv';
+
+        const items = filterMenuItems(menuItems, '', denyPdvRole);
+
+        expect(items.find((item) => item.path === '/pdv')).toBeUndefined();
+    });
+
+    it('matches search terms against labels, paths and keywords', () => {
+        const items = filterMenuItems(menuItems, 'cozinha produção', allowAllRoles);
+
+        expect(items.map((item) => item.label)).toContain('Cozinha Inteligente');
+    });
+
+    it('ignores diacritics when filtering by keywords', () => {
+        const items = filterMenuItems(menuItems, 'inventario produtos', allowAllRoles);
+
+        expect(items.map((item) => item.path)).toContain('/estoque');
+    });
+
+    it('requires every search term to match', () => {
+        const items = filterMenuItems(menuItems, 'admin inexistente', allowAllRoles);
+
+        expect(items).toHaveLength(0);
+    });
+});
+
+describe('buildSearchTerms', () => {
+    it('normalizes diacritics and casing', () => {
+        expect(buildSearchTerms('Início gestão')).toEqual(['inicio', 'gestao']);
+    });
+});

--- a/src/Apps/erp/menuItems.tsx
+++ b/src/Apps/erp/menuItems.tsx
@@ -14,6 +14,41 @@ export type MenuItem = {
     keywords?: string[];
 };
 
+const normalizeText = (value: string) =>
+    value
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase();
+
+export const buildSearchTerms = (searchTerm: string) =>
+    normalizeText(searchTerm)
+        .split(/\s+/)
+        .filter(Boolean);
+
+export const matchesMenuItemSearch = (item: MenuItem, terms: string[]) => {
+    if (!terms.length) return true;
+
+    const haystack = [
+        normalizeText(item.label),
+        normalizeText(item.path),
+        ...(item.keywords?.map(normalizeText) ?? []),
+    ].join(' ');
+
+    return terms.every((term) => haystack.includes(term));
+};
+
+export const filterMenuItems = (
+    items: MenuItem[],
+    searchTerm: string,
+    hasRole: (role: string) => boolean,
+) => {
+    const terms = buildSearchTerms(searchTerm);
+
+    return items.filter(
+        (item) => (!item.roles || item.roles.every(hasRole)) && matchesMenuItemSearch(item, terms),
+    );
+};
+
 export const menuItems: MenuItem[] = [
     {
         label: 'Home',

--- a/src/Apps/erp/shared/components/layout/components/sidemenu/Sidemenu.tsx
+++ b/src/Apps/erp/shared/components/layout/components/sidemenu/Sidemenu.tsx
@@ -1,39 +1,18 @@
 import { useMemo, useState } from 'react';
-import { Box, Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, OutlinedInput } from '@mui/material'
+import { Box, Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, OutlinedInput } from '@mui/material';
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '@shared/auth';
-import { MenuItem, menuItems } from 'menuItems';
+import { filterMenuItems, menuItems } from 'menuItems';
 
 export const Sidemenu: React.FC = () => {
     const { hasRole } = useAuth();
     const [searchTerm, setSearchTerm] = useState('');
 
-    const normalize = (value: string) =>
-        value
-            .normalize('NFD')
-            .replace(/\p{Diacritic}/gu, '')
-            .toLowerCase();
-
-    const filteredItems = useMemo(() => {
-        const terms = normalize(searchTerm).split(/\s+/).filter(Boolean);
-
-        const matchesSearch = (item: MenuItem) => {
-            if (!terms.length) return true;
-
-            const haystack = [
-                normalize(item.label),
-                normalize(item.path),
-                ...(item.keywords?.map(normalize) ?? []),
-            ].join(' ');
-
-            return terms.every((term) => haystack.includes(term));
-        };
-
-        return menuItems.filter(
-            (item) => (!item.roles || item.roles.every(hasRole)) && matchesSearch(item)
-        );
-    }, [hasRole, searchTerm]);
+    const filteredItems = useMemo(
+        () => filterMenuItems(menuItems, searchTerm, hasRole),
+        [hasRole, searchTerm],
+    );
 
     return (
         <>
@@ -62,7 +41,7 @@ export const Sidemenu: React.FC = () => {
                     aria-labelledby="nested-list-subheader"
                 >
                     {filteredItems.map((item) => (
-                        <ListItem key={item.path} sx={{ padding: 0 }} >
+                        <ListItem key={item.path} sx={{ padding: 0 }}>
                             <ListItemButton component={RouterLink} to={item.path}>
                                 <ListItemIcon>
                                     {item.icon}
@@ -75,5 +54,5 @@ export const Sidemenu: React.FC = () => {
 
             </Box>
         </>
-    )
-}
+    );
+};


### PR DESCRIPTION
## Summary
- centralize menu filtering logic for reuse and easier testing
- update the sidemenu component to rely on the shared filtering helpers
- add Jest coverage for menu search behavior and diacritic normalization

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org while fetching @emotion/react)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce29103dc83209ec831f27b95cc95)