### PR TITLE
Use gh cli for package version checks

### DIFF
--- a/.github/workflows/dotnet-sonar.yaml
+++ b/.github/workflows/dotnet-sonar.yaml
@@ -11,6 +11,8 @@ jobs:
   build-and-test:
     name: Build, Test and Analyze
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -33,7 +35,7 @@ jobs:
           dotnet-sonarscanner begin \
             /k:"evertonschuster_Cardapius" \
             /o:"evertonschuster-1" \
-            /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.login="$SONAR_TOKEN" \
             /d:sonar.cs.opencover.reportsPaths="coverage-report/*.xml" \
             /d:sonar.coverage.exclusions="**/*UnitTest*/**/*.cs,**/*Infra*/**/*.cs,**/Migrations/**,**/*Api*/**/*.cs,**/.github/**" \
             /d:sonar.projectBaseDir="$(pwd)"
@@ -45,4 +47,4 @@ jobs:
         run: bash scripts/run_tests.sh
 
       - name: End SonarCloud analysis
-        run: dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+        run: dotnet-sonarscanner end /d:sonar.login="$SONAR_TOKEN"

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -12,6 +12,10 @@ jobs:
   build-and-publish-packages:
     runs-on: ubuntu-latest
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,8 +26,6 @@ jobs:
           dotnet-version: '10.0.x'
           include-prerelease: true
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore dependencies
         run: dotnet restore src/Packages
@@ -32,17 +34,32 @@ jobs:
         run: dotnet build src/Packages --configuration Release --no-restore
 
       - name: Create and publish only updated packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          get_latest_version() {
+            local package_name="$1"
+            local owner_type="${{ github.repository_owner_type }}"
+            local owner_path
+
+            if [ "$owner_type" = "Organization" ]; then
+              owner_path="/orgs/${{ github.repository_owner }}"
+            else
+              owner_path="/users/${{ github.repository_owner }}"
+            fi
+
+            gh api -H "Accept: application/vnd.github+json" \
+              "$owner_path/packages/nuget/${package_name}/versions?per_page=1" \
+              --jq '.[0].name'
+          }
+
           for project in $(find src/Packages -name "*.csproj"); do
             PACKAGE_NAME=$(basename "$project" .csproj)
             VERSION=$(grep -oP '(?<=<Version>).*?(?=</Version>)' "$project")
 
             echo "🔍 Check $PACKAGE_NAME version $VERSION..."
 
-            # Get the latest version of the package already published on GitHub Packages
-            LATEST_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" | \
-              jq -r --arg pkg "$PACKAGE_NAME" '.data[] | select(.name==$pkg) | .version' | sort -V | tail -n 1)
+            LATEST_VERSION=$(get_latest_version "$PACKAGE_NAME")
 
             if [ "$VERSION" != "$LATEST_VERSION" ]; then
               echo "📦 Creating package $PACKAGE_NAME v$VERSION..."
@@ -57,8 +74,6 @@ jobs:
             echo "🚀 Publishing $package..."
             dotnet nuget push "$package" \
               --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
-              --api-key ${{ secrets.GITHUB_TOKEN }} \
+              --api-key "$NUGET_AUTH_TOKEN" \
               --skip-duplicate
           done
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace direct curl call using token with GitHub CLI to retrieve latest NuGet package versions
- keep tokens in environment variables when pushing packages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e383802d8832093ebf77e011206f0)