### PR TITLE
Improve auth service coverage

### DIFF
--- a/src/Apps/erp/shared/auth/services/authService.test.ts
+++ b/src/Apps/erp/shared/auth/services/authService.test.ts
@@ -39,6 +39,8 @@ describe('authService', () => {
     jest.clearAllMocks();
     mockCreateAuthClient.mockClear();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (authService as any).initialized = false;
+    (authService as any).userLoadedListeners?.clear?.();
     getUser.mockResolvedValue({ expired: false });
     signinRedirect.mockResolvedValue(undefined);
     signinRedirectCallback.mockResolvedValue({ state: { returnTo: '/home' } });

--- a/src/Apps/erp/shared/auth/services/authService.test.ts
+++ b/src/Apps/erp/shared/auth/services/authService.test.ts
@@ -81,10 +81,67 @@ describe('authService', () => {
     expect(signinRedirect).toHaveBeenCalled();
   });
 
+  it('returns error details when signin redirect fails', async () => {
+    signinRedirect.mockRejectedValueOnce(new TypeError('network down'));
+
+    const error = await authService.signinAsync();
+
+    expect(error?.code).toBe('network_error');
+    expect(error?.description).toBe('network down');
+    expect(error?.authority).toBe('auth');
+  });
+
   it('returns redirect from signinCallbackAsync', async () => {
     const response = await authService.signinCallbackAsync();
     expect(response.redirectTo).toBe('/home');
     expect(sessionStorage.getItem('returnTo')).toBeNull();
+  });
+
+  it('returns error from signinCallbackAsync when callback fails', async () => {
+    window.history.pushState({}, '', '/callback?error=server_error&error_description=bad');
+    signinRedirectCallback.mockRejectedValueOnce({
+      error: 'login_required',
+      state: { traceId: 't1', requestId: 'r1' },
+    });
+
+    const response = await authService.signinCallbackAsync();
+
+    expect(response.error?.title).toBe('Sua sessão expirou');
+    expect(response.error?.description).toBe('bad');
+    expect(response.error?.traceId).toBe('t1');
+    expect(response.error?.requestId).toBe('r1');
+    expect(response.error?.clientId).toBe('client');
+  });
+
+  it('sanitizes redirect when returning from auth routes', async () => {
+    sessionStorage.setItem('returnTo', '/callback?next=1');
+    signinRedirectCallback.mockResolvedValueOnce({ state: { returnTo: '/login/step' } });
+
+    const response = await authService.signinCallbackAsync();
+
+    expect(response.redirectTo).toBe('/');
+    expect(sessionStorage.getItem('returnTo')).toBeNull();
+  });
+
+  it('notifies userLoaded listeners and handles listener errors', async () => {
+    const okListener = jest.fn();
+    const failingListener = jest.fn(() => { throw new Error('boom'); });
+
+    const unsubscribe = authService.addUserLoaded(okListener);
+    authService.addUserLoaded(failingListener);
+
+    await authService.initAsync();
+    const userLoadedHandler = addUserLoaded.mock.calls[0][0];
+
+    userLoadedHandler({ name: 'john' } as any);
+    unsubscribe();
+    userLoadedHandler({ name: 'doe' } as any);
+
+    expect(okListener).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Erro em listener de userLoaded:',
+      expect.any(Error)
+    );
   });
 
   it('returns error details on signout failure', async () => {

--- a/src/Apps/erp/shared/auth/services/authService.test.ts
+++ b/src/Apps/erp/shared/auth/services/authService.test.ts
@@ -139,11 +139,12 @@ describe('authService', () => {
     unsubscribe();
     userLoadedHandler({ name: 'doe' } as any);
 
-    expect(okListener).toHaveBeenCalledTimes(2);
+    expect(okListener).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Erro em listener de userLoaded:',
       expect.any(Error)
     );
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
   });
 
   it('returns error details on signout failure', async () => {

--- a/src/Apps/erp/shared/auth/services/oidcService.test.ts
+++ b/src/Apps/erp/shared/auth/services/oidcService.test.ts
@@ -1,0 +1,56 @@
+import { OidcService } from './oidcService';
+
+describe('OidcService', () => {
+  describe('getOidcParamsFromUrl', () => {
+    it('parses search params when present', () => {
+      const params = OidcService.getOidcParamsFromUrl('http://site/cb?error=invalid&error_description=bad&error_uri=uri');
+
+      expect(params).toEqual({
+        error: 'invalid',
+        error_description: 'bad',
+        error_uri: 'uri',
+      });
+    });
+
+    it('falls back to hash fragment when search is empty', () => {
+      const params = OidcService.getOidcParamsFromUrl('http://site/cb#error=access_denied&error_description=blocked');
+
+      expect(params.error).toBe('access_denied');
+      expect(params.error_description).toBe('blocked');
+      expect(params.error_uri).toBeNull();
+    });
+  });
+
+  describe('checkIdpStatus', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('returns OK when endpoint is reachable', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+      await expect(OidcService.checkIdpStatus('http://idp')).resolves.toBe('OK');
+    });
+
+    it('returns HTTP status when response is not ok', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+      await expect(OidcService.checkIdpStatus('http://idp')).resolves.toBe('HTTP 503');
+    });
+
+    it('returns CORS when error mentions CORS', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('CORS policy')); 
+
+      await expect(OidcService.checkIdpStatus('http://idp')).resolves.toBe('CORS');
+    });
+
+    it('returns offline with error name when fetch fails', async () => {
+      const err = new Error('network down');
+      (err as any).name = 'FetchError';
+      global.fetch = jest.fn().mockRejectedValue(err);
+
+      await expect(OidcService.checkIdpStatus('http://idp')).resolves.toBe('OFFLINE (FetchError)');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add authService test cases for signin error handling, callback sanitization, and listener notifications
- add OidcService coverage for URL parsing and identity provider status responses

## Testing
- npm test -- --runInBand *(fails: npm install blocked by registry 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3eb9cfd08320a6936d5c7dc12df4)