### PR TITLE
Add tests for shared UI components

### DIFF
--- a/src/Apps/erp/shared/components/tests/Logo.test.tsx
+++ b/src/Apps/erp/shared/components/tests/Logo.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { Logo } from '../Logo';
+
+describe('Logo', () => {
+  it('shows the image and title by default', () => {
+    render(<Logo />);
+
+    const image = screen.getByAltText('Cardapius logo');
+    expect(image).toBeInTheDocument();
+    expect(screen.getByText('Cardapius')).toBeInTheDocument();
+  });
+
+  it('can hide the title when requested', () => {
+    render(<Logo showText={false} />);
+
+    expect(screen.getByAltText('Cardapius logo')).toBeInTheDocument();
+    expect(screen.queryByText('Cardapius')).not.toBeInTheDocument();
+  });
+});

--- a/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
+++ b/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
@@ -39,6 +39,7 @@ describe('SettingsHeader', () => {
     render(<SettingsHeader onClose={onClose} />);
 
     expect(screen.getByText('Configurações do sistema')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close settings/i })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /close settings/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -67,6 +68,19 @@ describe('ModeSection', () => {
     await user.click(screen.getByRole('button', { name: /light/i }));
     expect(setMode).not.toHaveBeenCalled();
   });
+
+  it('lets users toggle between modes sequentially', async () => {
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<ModeSection />, { mode: 'dark', setMode });
+
+    await user.click(screen.getByRole('button', { name: /light/i }));
+    await user.click(screen.getByRole('button', { name: /dark/i }));
+
+    expect(setMode).toHaveBeenNthCalledWith(1, 'light');
+    expect(setMode).toHaveBeenNthCalledWith(2, 'dark');
+  });
 });
 
 describe('SettingsDrawer', () => {
@@ -79,6 +93,7 @@ describe('SettingsDrawer', () => {
 
     expect(screen.getByText('Configurações do sistema')).toBeInTheDocument();
     expect(screen.getByText(/mode/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dark/i })).toHaveAttribute('aria-pressed', 'true');
 
     await user.click(screen.getByRole('button', { name: /close settings/i }));
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
+++ b/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
@@ -73,7 +73,22 @@ describe('ModeSection', () => {
     const setMode = jest.fn();
     const user = userEvent.setup();
 
-    renderWithTheme(<ModeSection />, { mode: 'dark', setMode });
+    const Wrapper = () => {
+      const [mode, setModeState] = React.useState<ThemeMode>('dark');
+
+      const handleSetMode = (nextMode: ThemeMode) => {
+        setMode(nextMode);
+        setModeState(nextMode);
+      };
+
+      return (
+        <ThemeContext.Provider value={{ mode, setMode: handleSetMode }}>
+          <ModeSection />
+        </ThemeContext.Provider>
+      );
+    };
+
+    render(<Wrapper />);
 
     await user.click(screen.getByRole('button', { name: /light/i }));
     await user.click(screen.getByRole('button', { name: /dark/i }));

--- a/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
+++ b/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModeSection } from '../layout/components/settings/ModeSection';
+import { SettingsDrawer } from '../layout/components/settings/SettingsDrawer';
+import { SettingsHeader } from '../layout/components/settings/SettingsHeader';
+import { SettingsSection } from '../layout/components/settings/SettingsSection';
+import { ThemeContext, ThemeMode } from '../../theme/ThemeContext';
+
+const renderWithTheme = (
+  ui: React.ReactNode,
+  { mode = 'light', setMode = jest.fn() }: { mode?: ThemeMode; setMode?: jest.Mock }
+) => {
+  return render(
+    <ThemeContext.Provider value={{ mode, setMode }}>
+      {ui}
+    </ThemeContext.Provider>
+  );
+};
+
+describe('SettingsSection', () => {
+  it('shows the provided label and content', () => {
+    render(
+      <SettingsSection label="Appearance">
+        <div>Custom content</div>
+      </SettingsSection>
+    );
+
+    expect(screen.getByText('Appearance')).toBeInTheDocument();
+    expect(screen.getByText('Custom content')).toBeInTheDocument();
+  });
+});
+
+describe('SettingsHeader', () => {
+  it('renders title and triggers close action', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(<SettingsHeader onClose={onClose} />);
+
+    expect(screen.getByText('Configurações do sistema')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close settings/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ModeSection', () => {
+  it('marks the current mode and switches when a new one is selected', async () => {
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<ModeSection />, { mode: 'light', setMode });
+
+    expect(screen.getByRole('button', { name: /light/i })).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(screen.getByRole('button', { name: /dark/i }));
+    expect(setMode).toHaveBeenCalledWith('dark');
+  });
+
+  it('ignores clicks that would unset the current selection', async () => {
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<ModeSection />, { mode: 'light', setMode });
+
+    await user.click(screen.getByRole('button', { name: /light/i }));
+    expect(setMode).not.toHaveBeenCalled();
+  });
+});
+
+describe('SettingsDrawer', () => {
+  it('renders the drawer content and propagates close actions', async () => {
+    const onClose = jest.fn();
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<SettingsDrawer open onClose={onClose} />, { mode: 'dark', setMode });
+
+    expect(screen.getByText('Configurações do sistema')).toBeInTheDocument();
+    expect(screen.getByText(/mode/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close settings/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Apps/erp/shared/components/tests/UserCard.test.tsx
+++ b/src/Apps/erp/shared/components/tests/UserCard.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserCard } from '../layout/components/user-card/UserCard';
+import { UserCardActions } from '../layout/components/user-card/UserCardActions';
+import { UserCardAvatar } from '../layout/components/user-card/UserCardAvatar';
+import { UserCardHeader } from '../layout/components/user-card/UserCardHeader';
+import { UserCardPlanChip } from '../layout/components/user-card/UserCardPlanChip';
+import { useAuth } from '@shared/auth';
+
+jest.mock('@shared/auth', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../layout/components/settings/SettingsDrawer', () => ({
+  SettingsDrawer: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
+    <div data-testid="settings-drawer" data-open={open} onClick={onClose} />
+  ),
+}));
+
+describe('UserCard', () => {
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: {
+        profile: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+        },
+      },
+    });
+    mockNavigate.mockReset();
+  });
+
+  it('shows header information and the default plan when expanded', () => {
+    render(<UserCard />);
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Starter')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('opens the settings drawer and routes to logout when icons are pressed', async () => {
+    const user = userEvent.setup();
+    render(<UserCard />);
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-open', 'true');
+
+    await user.click(buttons[1]);
+    expect(mockNavigate).toHaveBeenCalledWith('logout');
+  });
+
+  it('renders collapsed controls with the avatar tooltip and actions', async () => {
+    const user = userEvent.setup();
+    render(<UserCard collapsed />);
+
+    const avatar = screen.getByRole('img', { name: 'Jane Doe' });
+    expect(avatar).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-open', 'true');
+  });
+});
+
+describe('UserCardActions', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('calls the provided handlers for settings and logout', async () => {
+    const onOpenSettings = jest.fn();
+    const user = userEvent.setup();
+
+    render(<UserCardActions onOpenSettings={onOpenSettings} />);
+
+    const [settingsButton, logoutButton] = screen.getAllByRole('button');
+
+    await user.click(settingsButton);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+
+    await user.click(logoutButton);
+    expect(mockNavigate).toHaveBeenCalledWith('logout');
+  });
+});
+
+describe('UserCardAvatar', () => {
+  it('wraps the avatar with a badge when online', () => {
+    const { container } = render(
+      <UserCardAvatar name="Online User" avatarUrl="avatar.png" />
+    );
+
+    expect(screen.getByRole('img', { name: 'Online User' })).toBeInTheDocument();
+    expect(container.querySelector('.MuiBadge-badge')).toBeInTheDocument();
+  });
+
+  it('skips the badge when offline', () => {
+    const { container } = render(
+      <UserCardAvatar name="Offline User" avatarUrl="avatar.png" online={false} />
+    );
+
+    expect(screen.getByRole('img', { name: 'Offline User' })).toBeInTheDocument();
+    expect(container.querySelector('.MuiBadge-badge')).not.toBeInTheDocument();
+  });
+});
+
+describe('UserCardHeader', () => {
+  it('shows user identity and the associated plan chip', () => {
+    render(
+      <UserCardHeader
+        name="Header User"
+        email="header@example.com"
+        avatarUrl="header.png"
+        planLabel="Premium"
+      />
+    );
+
+    expect(screen.getByText('Header User')).toBeInTheDocument();
+    expect(screen.getByText('header@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Premium')).toBeInTheDocument();
+  });
+});
+
+describe('UserCardPlanChip', () => {
+  it('renders the plan label', () => {
+    render(<UserCardPlanChip label="Enterprise" />);
+
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for the Logo component behavior
- test settings layout pieces including header, section, mode selector, and drawer interactions

## Testing
- npm install *(fails: registry returned 403 Forbidden so dependencies could not be installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1b7d830483208f263b6c6e7bd76c)