### PR TITLE
Add layout coverage and ignore file mock from coverage

### DIFF
--- a/src/Apps/erp/jest.config.ts
+++ b/src/Apps/erp/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   moduleNameMapper: {
     '^@modules/(.*)$': '<rootDir>/modules/$1',
     '^@shared/(.*)$': '<rootDir>/shared/$1',
+    '^menuItems$': '<rootDir>/menuItems',
     '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.ts',
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/__mocks__/fileMock.ts'
   },

--- a/src/Apps/erp/jest.config.ts
+++ b/src/Apps/erp/jest.config.ts
@@ -20,6 +20,7 @@ const config: Config = {
       }
     ]
   },
+  coveragePathIgnorePatterns: ['<rootDir>/__mocks__/fileMock.ts'],
   coverageThreshold: {
     global: {
       branches: 80,

--- a/src/Apps/erp/shared/components/tests/LayoutComponents.test.tsx
+++ b/src/Apps/erp/shared/components/tests/LayoutComponents.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { AppLayout } from '../layout/AppLayout';
+import { Layout } from '../../ui/Layout';
+import { Sidebar } from '../layout/components/sidebar/Sidebar';
+import { Sidemenu } from '../layout/components/sidemenu/Sidemenu';
+
+jest.mock('@shared/components/Logo', () => ({
+  Logo: ({ showText }: { showText?: boolean }) => (
+    <div data-testid="logo" data-show-text={showText} />
+  ),
+}));
+
+jest.mock('../layout/components/user-card/UserCard', () => ({
+  UserCard: ({ collapsed }: { collapsed?: boolean }) => (
+    <div data-testid="user-card" data-collapsed={collapsed} />
+  ),
+}));
+
+const setCollapsedMock = jest.fn();
+jest.mock('@shared/hooks/usePersistentState', () => ({
+  usePersistentState: jest.fn(),
+}));
+
+jest.mock('@shared/auth', () => ({
+  useAuth: jest.fn(() => ({ hasRole: hasRoleMock })),
+}));
+
+const hasRoleMock = jest.fn((role?: string) => Boolean(role));
+
+describe('AppLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { usePersistentState } = jest.requireMock('@shared/hooks/usePersistentState');
+    (usePersistentState as jest.Mock).mockReturnValue([false, setCollapsedMock]);
+  });
+
+  it('renders the sidebar and provided children when present', () => {
+    render(
+      <MemoryRouter>
+        <AppLayout>
+          <div>Child Content</div>
+        </AppLayout>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+    expect(screen.getByText('Child Content')).toBeInTheDocument();
+  });
+
+  it('falls back to rendering the outlet content', () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<AppLayout />}>
+            <Route index element={<div>Outlet Value</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Outlet Value')).toBeInTheDocument();
+  });
+});
+
+jest.mock('@shared/theme', () => ({
+  AppThemeContext: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="theme-wrapper">{children}</div>
+  ),
+}));
+
+describe('Layout', () => {
+  it('wraps children with the theme provider container', () => {
+    render(
+      <Layout>
+        <div>Layout Child</div>
+      </Layout>
+    );
+
+    expect(screen.getByTestId('theme-wrapper')).toBeInTheDocument();
+    expect(screen.getByText('Layout Child')).toBeInTheDocument();
+  });
+});
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows expanded navigation with visible labels', async () => {
+    const user = userEvent.setup();
+    const { usePersistentState } = jest.requireMock('@shared/hooks/usePersistentState');
+    (usePersistentState as jest.Mock).mockReturnValue([false, setCollapsedMock]);
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('logo')).toHaveAttribute('data-show-text', 'true');
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+    expect(screen.getByTestId('user-card')).toHaveAttribute('data-collapsed', 'false');
+
+    await user.click(screen.getByRole('button'));
+    expect(setCollapsedMock).toHaveBeenCalledTimes(1);
+    const updater = setCollapsedMock.mock.calls[0][0];
+    expect(typeof updater).toBe('function');
+    expect(updater(false)).toBe(true);
+  });
+
+  it('collapses the sidebar and passes the collapsed flag forward', () => {
+    const { usePersistentState } = jest.requireMock('@shared/hooks/usePersistentState');
+    (usePersistentState as jest.Mock).mockReturnValue([true, setCollapsedMock]);
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('logo')).toHaveAttribute('data-show-text', 'false');
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-card')).toHaveAttribute('data-collapsed', 'true');
+  });
+});
+
+describe('Sidemenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasRoleMock.mockReturnValue(true);
+  });
+
+  it('filters menu items by the search term', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Sidemenu />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByPlaceholderText('Search'), 'admin');
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('hides the search input when collapsed', () => {
+    render(
+      <MemoryRouter>
+        <Sidemenu collapsed />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('link').length).toBeGreaterThan(0);
+  });
+
+  it('applies role-based filtering to the available routes', () => {
+    hasRoleMock.mockImplementation((role?: string) => role === 'pdv');
+
+    render(
+      <MemoryRouter>
+        <Sidemenu />
+      </MemoryRouter>
+    );
+
+    const labels = screen.getAllByRole('link').map((link) => link.textContent);
+    expect(labels).toEqual(expect.arrayContaining(['Home', 'Admin', 'PDV']));
+    expect(labels).not.toEqual(expect.arrayContaining(['Cozinha Inteligente', 'Estoque']));
+  });
+});

--- a/src/Apps/erp/shared/components/tests/Logo.test.tsx
+++ b/src/Apps/erp/shared/components/tests/Logo.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { Logo } from '../Logo';
+
+describe('Logo', () => {
+  it('shows the image and title by default', () => {
+    render(<Logo />);
+
+    const image = screen.getByAltText('Cardapius logo');
+    expect(image).toBeInTheDocument();
+    expect(screen.getByText('Cardapius')).toBeInTheDocument();
+  });
+
+  it('can hide the title when requested', () => {
+    render(<Logo showText={false} />);
+
+    expect(screen.getByAltText('Cardapius logo')).toBeInTheDocument();
+    expect(screen.queryByText('Cardapius')).not.toBeInTheDocument();
+  });
+});

--- a/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
+++ b/src/Apps/erp/shared/components/tests/SettingsComponents.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModeSection } from '../layout/components/settings/ModeSection';
+import { SettingsDrawer } from '../layout/components/settings/SettingsDrawer';
+import { SettingsHeader } from '../layout/components/settings/SettingsHeader';
+import { SettingsSection } from '../layout/components/settings/SettingsSection';
+import { ThemeContext, ThemeMode } from '../../theme/ThemeContext';
+
+const renderWithTheme = (
+  ui: React.ReactNode,
+  { mode = 'light', setMode = jest.fn() }: { mode?: ThemeMode; setMode?: jest.Mock }
+) => {
+  return render(
+    <ThemeContext.Provider value={{ mode, setMode }}>
+      {ui}
+    </ThemeContext.Provider>
+  );
+};
+
+describe('SettingsSection', () => {
+  it('shows the provided label and content', () => {
+    render(
+      <SettingsSection label="Appearance">
+        <div>Custom content</div>
+      </SettingsSection>
+    );
+
+    expect(screen.getByText('Appearance')).toBeInTheDocument();
+    expect(screen.getByText('Custom content')).toBeInTheDocument();
+  });
+});
+
+describe('SettingsHeader', () => {
+  it('renders title and triggers close action', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(<SettingsHeader onClose={onClose} />);
+
+    expect(screen.getByText('Configurações do sistema')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close settings/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close settings/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ModeSection', () => {
+  it('marks the current mode and switches when a new one is selected', async () => {
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<ModeSection />, { mode: 'light', setMode });
+
+    expect(screen.getByRole('button', { name: /light/i })).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(screen.getByRole('button', { name: /dark/i }));
+    expect(setMode).toHaveBeenCalledWith('dark');
+  });
+
+  it('ignores clicks that would unset the current selection', async () => {
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<ModeSection />, { mode: 'light', setMode });
+
+    await user.click(screen.getByRole('button', { name: /light/i }));
+    expect(setMode).not.toHaveBeenCalled();
+  });
+
+  it('lets users toggle between modes sequentially', async () => {
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    const Wrapper = () => {
+      const [mode, setModeState] = React.useState<ThemeMode>('dark');
+
+      const handleSetMode = (nextMode: ThemeMode) => {
+        setMode(nextMode);
+        setModeState(nextMode);
+      };
+
+      return (
+        <ThemeContext.Provider value={{ mode, setMode: handleSetMode }}>
+          <ModeSection />
+        </ThemeContext.Provider>
+      );
+    };
+
+    render(<Wrapper />);
+
+    await user.click(screen.getByRole('button', { name: /light/i }));
+    await user.click(screen.getByRole('button', { name: /dark/i }));
+
+    expect(setMode).toHaveBeenNthCalledWith(1, 'light');
+    expect(setMode).toHaveBeenNthCalledWith(2, 'dark');
+  });
+});
+
+describe('SettingsDrawer', () => {
+  it('renders the drawer content and propagates close actions', async () => {
+    const onClose = jest.fn();
+    const setMode = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(<SettingsDrawer open onClose={onClose} />, { mode: 'dark', setMode });
+
+    expect(screen.getByText('Configurações do sistema')).toBeInTheDocument();
+    expect(screen.getByText(/mode/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dark/i })).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(screen.getByRole('button', { name: /close settings/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Apps/erp/shared/components/tests/UserCard.test.tsx
+++ b/src/Apps/erp/shared/components/tests/UserCard.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserCard } from '../layout/components/user-card/UserCard';
+import { UserCardActions } from '../layout/components/user-card/UserCardActions';
+import { UserCardAvatar } from '../layout/components/user-card/UserCardAvatar';
+import { UserCardHeader } from '../layout/components/user-card/UserCardHeader';
+import { UserCardPlanChip } from '../layout/components/user-card/UserCardPlanChip';
+import { useAuth } from '@shared/auth';
+
+jest.mock('@shared/auth', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../layout/components/settings/SettingsDrawer', () => ({
+  SettingsDrawer: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
+    <div data-testid="settings-drawer" data-open={open} onClick={onClose} />
+  ),
+}));
+
+describe('UserCard', () => {
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: {
+        profile: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+        },
+      },
+    });
+    mockNavigate.mockReset();
+  });
+
+  it('shows header information and the default plan when expanded', () => {
+    render(<UserCard />);
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Starter')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('opens the settings drawer and routes to logout when icons are pressed', async () => {
+    const user = userEvent.setup();
+    render(<UserCard />);
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-open', 'true');
+
+    await user.click(buttons[1]);
+    expect(mockNavigate).toHaveBeenCalledWith('logout');
+  });
+
+  it('renders collapsed controls with the avatar tooltip and actions', async () => {
+    const user = userEvent.setup();
+    render(<UserCard collapsed />);
+
+    const avatar = screen.getByRole('img', { name: 'Jane Doe' });
+    expect(avatar).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-open', 'true');
+  });
+});
+
+describe('UserCardActions', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('calls the provided handlers for settings and logout', async () => {
+    const onOpenSettings = jest.fn();
+    const user = userEvent.setup();
+
+    render(<UserCardActions onOpenSettings={onOpenSettings} />);
+
+    const [settingsButton, logoutButton] = screen.getAllByRole('button');
+
+    await user.click(settingsButton);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+
+    await user.click(logoutButton);
+    expect(mockNavigate).toHaveBeenCalledWith('logout');
+  });
+});
+
+describe('UserCardAvatar', () => {
+  it('wraps the avatar with a badge when online', () => {
+    const { container } = render(
+      <UserCardAvatar name="Online User" avatarUrl="avatar.png" />
+    );
+
+    expect(screen.getByRole('img', { name: 'Online User' })).toBeInTheDocument();
+    expect(container.querySelector('.MuiBadge-badge')).toBeInTheDocument();
+  });
+
+  it('skips the badge when offline', () => {
+    const { container } = render(
+      <UserCardAvatar name="Offline User" avatarUrl="avatar.png" online={false} />
+    );
+
+    expect(screen.getByRole('img', { name: 'Offline User' })).toBeInTheDocument();
+    expect(container.querySelector('.MuiBadge-badge')).not.toBeInTheDocument();
+  });
+});
+
+describe('UserCardHeader', () => {
+  it('shows user identity and the associated plan chip', () => {
+    render(
+      <UserCardHeader
+        name="Header User"
+        email="header@example.com"
+        avatarUrl="header.png"
+        planLabel="Premium"
+      />
+    );
+
+    expect(screen.getByText('Header User')).toBeInTheDocument();
+    expect(screen.getByText('header@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Premium')).toBeInTheDocument();
+  });
+});
+
+describe('UserCardPlanChip', () => {
+  it('renders the plan label', () => {
+    render(<UserCardPlanChip label="Enterprise" />);
+
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AppLayout, Layout, Sidebar, and Sidemenu covering navigation display, outlet fallback, and role-based filtering
- mock shared dependencies to validate collapsed/expanded sidebar behavior and search filtering
- exclude the file mock helper from Jest coverage collection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1b7d830483208f263b6c6e7bd76c)